### PR TITLE
Return null instead of false if no model or cursor can be returned

### DIFF
--- a/src/Zizaco/Mongolid/Model.php
+++ b/src/Zizaco/Mongolid/Model.php
@@ -187,13 +187,13 @@ class Model
      *
      * @param  mixed  $id
      * @param  array  $fields
-     * @return Zizaco\Mongolid\MongoModel
+     * @return Zizaco\Mongolid\MongoModel|null
      */
     public static function first($id = array(), $fields = array())
     {
         $instance = static::newInstance();
 
-        if (! $instance->collection) return false;
+        if (! $instance->collection) return null;
 
         // Get query array
         $query = $instance->prepareQuery($id);
@@ -209,7 +209,7 @@ class Model
             $instance = $instance->polymorph( $instance );
             return $instance;
         } else {
-            return false;
+            return null;
         }
     }
 
@@ -240,14 +240,14 @@ class Model
      * @param  array  $query
      * @param  array  $fields
      * @param  boolean  $cachable
-     * @return Zizaco\Mongolid\OdmCursor
+     * @return Zizaco\Mongolid\OdmCursor|null
      */
     public static function where($query = array(), $fields = array(), $cachable = false)
     {
         $instance = static::newInstance();
 
         if (! $instance->collection)
-            return false;
+            return null;
 
         // Get query array
         $query = $instance->prepareQuery($query);


### PR DESCRIPTION
I believe it makes more sense to return `null` instead of the boolean value `false` (whereas `true` is never possible).

This would also fix a problem in mongolid-laravel (https://github.com/Zizaco/mongolid-laravel/pull/50).
