### PR TITLE
Adding 'aggregate' to Mongolid\Model

### DIFF
--- a/src/Zizaco/Mongolid/Model.php
+++ b/src/Zizaco/Mongolid/Model.php
@@ -2,6 +2,7 @@
 namespace Zizaco\Mongolid;
 
 use MongoClient, MongoDate;
+use MongoCollection;
 
 class Model
 {
@@ -333,6 +334,30 @@ class Model
     public static function all( $fields = array() )
     {
         return static::where( array(), $fields );
+    }
+
+    /**
+     * Uses the aggregation framework to find results
+     *
+     * @param $pipeline
+     * @param array $ops
+     * @return null|array
+     */
+    public static function aggregate($pipeline, $ops = array())
+    {
+        /** @var Model $instance */
+        $instance = static::newInstance();
+        if(!$instance->collection) {
+            return null;
+        }
+        /** @var MongoCollection $collection */
+        $collection = $instance->collection();
+        $results = $collection->aggregate($pipeline, $ops);
+        if(isset($results['ok']) && $results['ok'] == 0) {
+            return null;
+        } else {
+            return $results['result'];
+        }
     }
 
     /**

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1,13 +1,18 @@
 <?php
 
+use Mockery\Mock;
 use Zizaco\Mongolid\Model;
 use Mockery as m;
 
 class ModelTest extends PHPUnit_Framework_TestCase
 {
+    /** @var Mock */
     protected $mongoMock = null;
+    /** @var Mock */
     protected $productsCollection = null;
+    /** @var Mock */
     protected $categoriesCollection = null;
+    /** @var Mock */
     protected $cursor = null;
 
     public function setUp()
@@ -669,6 +674,39 @@ class ModelTest extends PHPUnit_Framework_TestCase
 
         $result = $prod1->polymorph($prod1);
         $this->assertEquals($prod1, $result);
+    }
+
+    public function testAggregateReturnsNullForEmptyCollection()
+    {
+        $null = _stubCharacteristic::aggregate(array());
+        $this->assertNull($null);
+    }
+
+    public function testAggregateReturnsNullIfNotOk()
+    {
+        $this->categoriesCollection
+            ->shouldReceive('aggregate')
+            ->with(array(), array())
+            ->andReturn(array(
+                'ok' => 0
+            ));
+        $null = _stubCategory::aggregate(array());
+        $this->assertNull($null);
+    }
+
+    public function testAggregateReturnsResultKey()
+    {
+        $this->categoriesCollection
+            ->shouldReceive('aggregate')
+            ->with(array(), array())
+            ->andReturn(array(
+                'result' => array(
+                    'test' => 'value'
+                )
+            ));
+        $result = _stubCategory::aggregate(array());
+        $this->assertArrayHasKey('test', $result);
+        $this->assertEquals('value', $result['test']);
     }
 
     /**


### PR DESCRIPTION
Used for Mongo's aggregation framework, this allows for static reference to the aggregation framework.