### PR TITLE
Non global connection

### DIFF
--- a/src/Mongolid/Connection/Connection.php
+++ b/src/Mongolid/Connection/Connection.php
@@ -1,97 +1,52 @@
-<?php namespace Mongolid\Connection;
+<?php
+namespace Mongolid\Connection;
 
 use MongoConnectionException;
 use Mongolid\Container\Ioc;
+use MongoClient;
 
 /**
- * Responsable for create a new or reuse a connection with MongoDB.
+ * Represents a single connection with the database
+ *
+ * @package  Mongolid
  */
 class Connection
 {
     /**
-     * MongoClient instance shared.
+     * The raw MongoClient object that represents this connection
      *
      * @var MongoClient
      */
-    public static $sharedConnection;
+    protected $rawConnection;
 
     /**
-     * Collection's name.
-     * @var mixed
-     */
-    protected $collection = false;
-
-    /**
-     * Database's name.
-     * @var string
-     */
-    protected $database = false;
-
-    /**
-     * Write concern.
-     * @var integer
-     */
-    protected $writeConcern = 1;
-
-    /**
-     * Creates a new connection with database.
+     * Constructs a new Mongolid connection. It uses the same constructor
+     * parameters as the original MongoClient constructor
      *
-     * @param  string $connectionString
-     * @return MongoClient
+     * @see   http://php.net/manual/pt_BR/mongoclient.construct.php
+     *
+     * @param string $server Connection string
+     * @param array  $options
+     * @param array  $driver_options
      */
-    protected function createConnection($connectionString = '')
-    {
-        if (static::$sharedConnection) {
-            return static::$sharedConnection;
-        }
-
-        try {
-            $connection = Ioc::make('MongoClient', [$connectionString, []]);
-            static::$sharedConnection = $connection;
-        } catch (MongoConnectionException $e) {
-            throw new MongoConnectionException(
-                "Failed to connect with string: $connectionString",
-                1,
-                $e
-            );
-        }
-
-        return static::$sharedConnection;
+    public function __construct(
+        $server = "mongodb://localhost:27017",
+        $options = ["connect" => TRUE],
+        $driver_options = []
+    ) {
+        $this->rawConnection = Ioc::make(
+            'MongoClient',
+            [$server, $options, $driver_options]
+        );
     }
 
     /**
      * Getter for MongoClient instance
+     *
      * @return MongoClient
      */
-    public function getConnectionInstance()
+    public function getRawConnection()
     {
-        return $this->createConnection();
-    }
-
-    /**
-     * Returns the collection's name
-     * @return mixed
-     */
-    public function setCollection($collectionName)
-    {
-        return $this->collection = $collectionName;
-    }
-
-    /**
-     * Returns the database's name
-     * @return mixed
-     */
-    public function setDatabase($databaseName)
-    {
-        return $this->database = $databaseName;
-    }
-
-    /**
-     * Returns the database's name
-     * @return mixed
-     */
-    public function setWriteConcern($w)
-    {
-        return $this->writeConcern = $w;
+        return $this->rawConnection;
     }
 }

--- a/src/Mongolid/Connection/Pool.php
+++ b/src/Mongolid/Connection/Pool.php
@@ -1,0 +1,53 @@
+<?php
+namespace Mongolid\Connection;
+
+use Mongolid\Container\Ioc;
+
+/**
+ * Holds one or more connections and retrieve then as needed. It contains a
+ * cache of connections maintained so that the connections can be reused when
+ * future requests to the database are required.
+ *
+ * @package Mongolid
+ */
+class Pool
+{
+    /**
+     * Openned connections
+     * @var SplQueue
+     */
+    protected $connections;
+
+    /**
+     * Contructs a connection pool
+     */
+    public function __construct()
+    {
+        $this->connections = Ioc::make('SplQueue');
+    }
+
+    /**
+     * Gets a connection from the pool. It will cicle trought the existent
+     * connections.
+     *
+     * @return Connection
+     */
+    public function getConnection()
+    {
+        if ($chosenConn = $this->connections->pop()) {
+            $this->connections->push($chosenConn);
+            return $chosenConn;
+        }
+    }
+
+    /**
+     * Adds a new connection to the pool
+     *
+     * @return  bool Success
+     */
+    public function addConnection(Connection $conn)
+    {
+        $this->connections->push($conn);
+        return true;
+    }
+}

--- a/tests/Mongolid/Connection/PoolTest.php
+++ b/tests/Mongolid/Connection/PoolTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Mongolid\Connection;
+
+use TestCase;
+use Mockery as m;
+use Mongolid\Container\Ioc;
+
+class PoolTest extends TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testShouldGetAConnectionFromPoolIfContainsAny()
+    {
+        // Arrange
+        $pool       = new Pool;
+        $connQueue  = m::mock();
+        $connection = m::mock('Mongolid\Connection\Connection');
+        $this->setProtected($pool, 'connections', $connQueue);
+
+        // Act
+        $connQueue->shouldReceive('pop')
+            ->once()
+            ->andReturn($connection);
+
+        $connQueue->shouldReceive('push')
+            ->once()
+            ->with($connection);
+
+        // Assert
+        $this->assertEquals($connection, $pool->getConnection());
+    }
+
+    public function testShouldGetNullConnectionFromPoolIfItsEmpty()
+    {
+        // Arrange
+        $pool       = new Pool;
+        $connQueue  = m::mock();
+        $this->setProtected($pool, 'connections', $connQueue);
+
+        // Act
+        $connQueue->shouldReceive('pop')
+            ->once()
+            ->andReturn(null);
+
+        $connQueue->shouldReceive('push')
+            ->never();
+
+        // Assert
+        $this->assertNull($pool->getConnection());
+    }
+
+    public function testShouldAddConnectionToPool()
+    {
+        // Arrange
+        $pool       = new Pool;
+        $connQueue  = m::mock();
+        $connection = m::mock('Mongolid\Connection\Connection');
+        $this->setProtected($pool, 'connections', $connQueue);
+
+        // Act
+        $connQueue->shouldReceive('push')
+            ->once()
+            ->with($connection);
+
+        // Assert
+        $this->assertTrue($pool->addConnection($connection));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,4 +34,25 @@ class TestCase extends PHPUnit_Framework_TestCase
 
         return $methodObj->invokeArgs($obj, $args);
     }
+
+    /**
+     * Call a protected property of an object
+     *
+     * @param  mixed $obj
+     * @param  string $attribute Property name
+     * @param  mixed  $value Value to be set
+     */
+    protected function setProtected($obj, $property, $value)
+    {
+        $class = new ReflectionClass($obj);
+        $property = $class->getProperty($property);
+        $property->setAccessible(true);
+
+        if (is_string($obj)) { // static
+            $property->setValue($value);
+            return;
+        }
+
+        $property->setValue($obj, $value);
+    }
 }


### PR DESCRIPTION
Updated `Connection\Connection` to represent a single connection (instead of holding a `static` globallike connecton)

**EDIT:**

The `--testdox` output of this pr:
```
Mongolid\Connection\Connection
 [x] Should construct a new connection
 [x] Should get raw connection

Mongolid\Connection\Pool
 [x] Should get a connection from pool if contains any
 [x] Should get null connection from pool if its empty
 [x] Should add connection to pool
```