### PR TITLE
DataMapper implementation

### DIFF
--- a/src/Mongolid/Connection/Connection.php
+++ b/src/Mongolid/Connection/Connection.php
@@ -1,97 +1,52 @@
-<?php namespace Mongolid\Connection;
+<?php
+namespace Mongolid\Connection;
 
 use MongoConnectionException;
 use Mongolid\Container\Ioc;
+use MongoClient;
 
 /**
- * Responsable for create a new or reuse a connection with MongoDB.
+ * Represents a single connection with the database
+ *
+ * @package  Mongolid
  */
 class Connection
 {
     /**
-     * MongoClient instance shared.
+     * The raw MongoClient object that represents this connection
      *
      * @var MongoClient
      */
-    public static $sharedConnection;
+    protected $rawConnection;
 
     /**
-     * Collection's name.
-     * @var mixed
-     */
-    protected $collection = false;
-
-    /**
-     * Database's name.
-     * @var string
-     */
-    protected $database = false;
-
-    /**
-     * Write concern.
-     * @var integer
-     */
-    protected $writeConcern = 1;
-
-    /**
-     * Creates a new connection with database.
+     * Constructs a new Mongolid connection. It uses the same constructor
+     * parameters as the original MongoClient constructor
      *
-     * @param  string $connectionString
-     * @return MongoClient
+     * @see   http://php.net/manual/pt_BR/mongoclient.construct.php
+     *
+     * @param string $server Connection string
+     * @param array  $options
+     * @param array  $driver_options
      */
-    protected function createConnection($connectionString = '')
-    {
-        if (static::$sharedConnection) {
-            return static::$sharedConnection;
-        }
-
-        try {
-            $connection = Ioc::make('MongoClient', [$connectionString, []]);
-            static::$sharedConnection = $connection;
-        } catch (MongoConnectionException $e) {
-            throw new MongoConnectionException(
-                "Failed to connect with string: $connectionString",
-                1,
-                $e
-            );
-        }
-
-        return static::$sharedConnection;
+    public function __construct(
+        $server = "mongodb://localhost:27017",
+        $options = ["connect" => TRUE],
+        $driver_options = []
+    ) {
+        $this->rawConnection = Ioc::make(
+            'MongoClient',
+            [$server, $options, $driver_options]
+        );
     }
 
     /**
      * Getter for MongoClient instance
+     *
      * @return MongoClient
      */
-    public function getConnectionInstance()
+    public function getRawConnection()
     {
-        return $this->createConnection();
-    }
-
-    /**
-     * Returns the collection's name
-     * @return mixed
-     */
-    public function setCollection($collectionName)
-    {
-        return $this->collection = $collectionName;
-    }
-
-    /**
-     * Returns the database's name
-     * @return mixed
-     */
-    public function setDatabase($databaseName)
-    {
-        return $this->database = $databaseName;
-    }
-
-    /**
-     * Returns the database's name
-     * @return mixed
-     */
-    public function setWriteConcern($w)
-    {
-        return $this->writeConcern = $w;
+        return $this->rawConnection;
     }
 }

--- a/src/Mongolid/Connection/Pool.php
+++ b/src/Mongolid/Connection/Pool.php
@@ -1,0 +1,53 @@
+<?php
+namespace Mongolid\Connection;
+
+use Mongolid\Container\Ioc;
+
+/**
+ * Holds one or more connections and retrieve then as needed. It contains a
+ * cache of connections maintained so that the connections can be reused when
+ * future requests to the database are required.
+ *
+ * @package Mongolid
+ */
+class Pool
+{
+    /**
+     * Openned connections
+     * @var SplQueue
+     */
+    protected $connections;
+
+    /**
+     * Contructs a connection pool
+     */
+    public function __construct()
+    {
+        $this->connections = Ioc::make('SplQueue');
+    }
+
+    /**
+     * Gets a connection from the pool. It will cicle trought the existent
+     * connections.
+     *
+     * @return Connection
+     */
+    public function getConnection()
+    {
+        if ($chosenConn = $this->connections->pop()) {
+            $this->connections->push($chosenConn);
+            return $chosenConn;
+        }
+    }
+
+    /**
+     * Adds a new connection to the pool
+     *
+     * @return  bool Success
+     */
+    public function addConnection(Connection $conn)
+    {
+        $this->connections->push($conn);
+        return true;
+    }
+}

--- a/src/Mongolid/DataMapper/DataMapper.php
+++ b/src/Mongolid/DataMapper/DataMapper.php
@@ -1,0 +1,169 @@
+<?php
+namespace Mongolid\DataMapper;
+
+use Mongolid\Schema;
+use Mongolid\Container\Ioc;
+
+class DataMapper
+{
+    /**
+     * Name of the collection where the object is going to be saved or retrieved
+     * from
+     * @var string
+     */
+    public $collection = 'mongolid';
+
+    /**
+     * Name of the schema class to be used
+     * @var string
+     */
+    public $schemaClass = 'Mongolid\Schema';
+
+    /**
+     * Schema object. Will be set after the $schemaClass
+     * @var Schema
+     */
+    public $schema;
+
+    /**
+     * Upserts the given object into database. Returns success if write concern
+     * is acknowledged.
+     *
+     * @return boolean Success (but always false if write concern is Unacknowledged)
+     */
+    public function save($object)
+    {
+        return $this->performCommand(
+            'upsert',
+            $this->collection,
+            $this->parseToDocument($object)
+        );
+    }
+
+    /**
+     * Inserts the given object into database. Returns success if write concern
+     * is acknowledged. Since it's an insert, it will fail if the _id already
+     * exists.
+     *
+     * @return boolean Success (but always false if write concern is Unacknowledged)
+     */
+    public function insert($object)
+    {
+        return $this->performCommand(
+            'insert',
+            $this->collection,
+            $this->parseToDocument($object)
+        );
+    }
+
+    /**
+     * Updates the given object into database. Returns success if write concern
+     * is acknowledged. Since it's an update, it will fail if the document with
+     * the given _id didn't exists.
+     *
+     * @return boolean Success (but always false if write concern is Unacknowledged)
+     */
+    public function update($object)
+    {
+        return $this->performCommand(
+            'update',
+            $this->collection,
+            $this->parseToDocument($object)
+        );
+    }
+
+    /**
+     * Retrieve a database cursor that will return $this->schema->entityClass
+     * objects that upon iteration
+     *
+     * @param  array $query MongoDB query to retrieve documents
+     *
+     * @return \Mongolid\Cursor\Cursor
+     */
+    public function where($query = [])
+    {
+        $rawCursor = $this->performCommand(
+            'where',
+            $this->collection,
+            $query
+        );
+
+        return Ioc::make(
+            'Mongolid\Cursor\Cursor',
+            [$rawCursor, $this->getSchemaMapper()->entityClass]
+        );
+    }
+
+    /**
+     * Retrieve a database cursor that will return all documents as
+     * $this->schema->entityClass objects upon iteration
+     *
+     * @return \Mongolid\Cursor\Cursor
+     */
+    public function all()
+    {
+        return $this->where([]);
+    }
+
+    /**
+     * Retrieve one $this->schema->entityClass objects that matches the given
+     * query
+     *
+     * @param  array $query MongoDB query to retrieve the document
+     *
+     * @return mixed First document matching query as an $this->schema->entityClass object
+     */
+    public function first($query)
+    {
+        return $this->where($query)->limit(1)->first();
+    }
+
+    /**
+     * Parses an object with SchemaMapper and the given Schema
+     *
+     * @param  mixed  $object
+     *
+     * @return array  Document
+     */
+    protected function parseToDocument($object)
+    {
+        $schemaMapper = $this->getSchemaMapper();
+        $object       = $this->parseToArray($object);
+
+        return $schemaMapper->map($object);
+    }
+
+    /**
+     * Returns a SchemaMapper with the $schema or $schemaClass instance
+     *
+     * @return SchemaMapper
+     */
+    protected function getSchemaMapper()
+    {
+        if (! $this->schema) {
+            $this->schema = Ioc::make($this->schemaClass);
+        }
+
+        return Ioc::make('Mongolid\DataMapper\SchemaMapper', [$this->schema]);
+    }
+
+    /**
+     * Parses an object to an array before sending it to the SchemaMapper
+     *
+     * @param  mixed $object
+     *
+     * @return array
+     */
+    protected function parseToArray($object)
+    {
+        if (! is_array($object)) {
+            if (method_exists($object, 'toArray')) {
+                return $object->toArray();
+            }
+
+            return get_object_vars($object);
+        }
+
+        return $object;
+    }
+}

--- a/src/Mongolid/DataMapper/DataMapper.php
+++ b/src/Mongolid/DataMapper/DataMapper.php
@@ -4,6 +4,14 @@ namespace Mongolid\DataMapper;
 use Mongolid\Schema;
 use Mongolid\Container\Ioc;
 
+/**
+ * The DataMapper class will abstract how an Entity is persisted and retrieved
+ * from the database.
+ * The DataMapper will always use a Schema trought the SchemaMapper to parse the
+ * document in and out of the database.
+ *
+ * @package  Mongolid
+ */
 class DataMapper
 {
     /**

--- a/src/Mongolid/DataMapper/DataMapper.php
+++ b/src/Mongolid/DataMapper/DataMapper.php
@@ -41,7 +41,7 @@ class DataMapper
      */
     public function save($object)
     {
-        return $this->performCommand(
+        return $this->performQuery(
             'upsert',
             $this->collection,
             $this->parseToDocument($object)
@@ -57,7 +57,7 @@ class DataMapper
      */
     public function insert($object)
     {
-        return $this->performCommand(
+        return $this->performQuery(
             'insert',
             $this->collection,
             $this->parseToDocument($object)
@@ -73,7 +73,7 @@ class DataMapper
      */
     public function update($object)
     {
-        return $this->performCommand(
+        return $this->performQuery(
             'update',
             $this->collection,
             $this->parseToDocument($object)
@@ -90,7 +90,7 @@ class DataMapper
      */
     public function where($query = [])
     {
-        $rawCursor = $this->performCommand(
+        $rawCursor = $this->performQuery(
             'where',
             $this->collection,
             $query
@@ -173,5 +173,20 @@ class DataMapper
         }
 
         return $object;
+    }
+
+    /**
+     * Performs a query into database
+     *
+     * @param  string $command    Which command should be executed
+     * @param  string $collection Name of the collection
+     * @param  array  $param      Command parameter
+     *
+     * @return mixed
+     */
+    protected function performQuery($command, $collection, $param)
+    {
+        $query = Ioc::make('Mongolid\DataMapper\Query');
+        return $query->$command($collection, $param);
     }
 }

--- a/src/Mongolid/DataMapper/SchemaMapper.php
+++ b/src/Mongolid/DataMapper/SchemaMapper.php
@@ -43,7 +43,7 @@ class SchemaMapper
      */
     public function map(array $data)
     {
-        $this->parseDynamicAttributes($data);
+        $this->clearDynamic($data);
 
         // Parse each specified field
         foreach ($this->schema->fields as $key => $fieldType) {
@@ -60,7 +60,7 @@ class SchemaMapper
      *
      * @param  array  &$data
      */
-    protected function parseDynamicAttributes(array &$data)
+    protected function clearDynamic(array &$data)
     {
         if (! $this->schema->dynamic) {
             $data = array_intersect_key($data, $this->schema->fields);
@@ -103,7 +103,7 @@ class SchemaMapper
      */
     protected function cast($value, $type)
     {
-        settype($value, $fieldType);
+        settype($value, $type);
         return $value;
     }
 
@@ -120,7 +120,7 @@ class SchemaMapper
     {
         if (is_array($value)) {
             $schema = Ioc::make($schemaClass);
-            $mapper = new SchemaMapper($schema);
+            $mapper = Ioc::make('Mongolid\DataMapper\SchemaMapper', [$schema]);
             return $mapper->map($value);
         }
 

--- a/src/Mongolid/DataMapper/SchemaMapper.php
+++ b/src/Mongolid/DataMapper/SchemaMapper.php
@@ -1,0 +1,129 @@
+<?php
+namespace Mongolid\DataMapper;
+
+use Mongolid\Schema;
+use Mongolid\Container\Ioc;
+
+/**
+ * The SchemaMapper will map an array of data to an Schema object. When
+ * instantiating a SchemaMapper you should provide a Schema. When calling 'map'
+ * the Schema provided will be used to format the data to the correct format.
+ *
+ * @package  Mongolid
+ */
+class SchemaMapper
+{
+    /**
+     * The actual schema to maps the data
+     * @var Schema
+     */
+    public $schema;
+
+    /**
+     * Types that can be casted
+     * @see http://php.net/manual/en/language.types.type-juggling.php
+     * @var string[]
+     */
+    protected $castableTypes = ['int','integer','bool','boolean','float','double','real','string'];
+
+    /**
+     * @param Schema $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * Maps the input $data to the schema specified in the $schema property
+     *
+     * @param  array  $data
+     *
+     * @return array
+     */
+    public function map(array $data)
+    {
+        $this->parseDynamicAttributes($data);
+
+        // Parse each specified field
+        foreach ($this->schema->fields as $key => $fieldType) {
+            if (isset($data[$key])) {
+                $data[$key] = $this->parseField($data[$key], $fieldType);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * If the schema is not dynamic, remove all non specified fields
+     *
+     * @param  array  &$data
+     */
+    protected function parseDynamicAttributes(array &$data)
+    {
+        if (! $this->schema->dynamic) {
+            $data = array_intersect_key($data, $this->schema->fields);
+        }
+    }
+
+    /**
+     * Parse a value based on a field yype of the schema
+     *
+     * @param  mixed  $value Value to be parsed
+     * @param  string $fieldType  Description of how the field should be treated
+     *
+     * @return mixed  $value Value parsed to match $type
+     */
+    public function parseField($value, $fieldType)
+    {
+        // If fieldType is castable (Ex: 'int')
+        if (in_array($fieldType, $this->castableTypes)) {
+            return $this->cast($value, $fieldType);
+        }
+
+        // If the field type points to another schema.
+        if (substr($fieldType, 0, 7) == 'schema.') {
+            return $this->mapToSchema($value, substr($fieldType, 7));
+        }
+
+        // Uses $fieldType method of the schema to parse the value
+        return $this->schema->$fieldType($value);
+    }
+
+    /**
+     * Uses PHP's settype to cast a value to a type
+     *
+     * @see http://php.net/manual/pt_BR/function.settype.php
+     *
+     * @param  mixed  $value
+     * @param  string $type
+     *
+     * @return mixed
+     */
+    protected function cast($value, $type)
+    {
+        settype($value, $fieldType);
+        return $value;
+    }
+
+    /**
+     * Instantiate another SchemaMapper with the given $schemaClass and maps
+     * the given $value
+     *
+     * @param  mixed $value
+     * @param  string $schemaClass Name of the class that will be instantiated and passed to the new SchemaMapper constructor
+     *
+     * @return mixed
+     */
+    protected function mapToSchema($value, $schemaClass)
+    {
+        if (is_array($value)) {
+            $schema = Ioc::make($schemaClass);
+            $mapper = new SchemaMapper($schema);
+            return $mapper->map($value);
+        }
+
+        return null;
+    }
+}

--- a/src/Mongolid/DynamicSchema.php
+++ b/src/Mongolid/DynamicSchema.php
@@ -1,0 +1,17 @@
+<?php
+namespace Mongolid;
+
+/**
+ * The DynamicSchema will accept additional fields that are not specified in
+ * the $schema property. This is usefull if you doesn't have a clear idea of how
+ * tthe document will look like
+ *
+ * @package  Mongolid
+ */
+class DynamicSchema extends Schema
+{
+    /**
+     * {@inheritsdoc}
+     */
+    protected $dynamic = true;
+}

--- a/src/Mongolid/DynamicSchema.php
+++ b/src/Mongolid/DynamicSchema.php
@@ -13,5 +13,5 @@ class DynamicSchema extends Schema
     /**
      * {@inheritsdoc}
      */
-    protected $dynamic = true;
+    public $dynamic = true;
 }

--- a/src/Mongolid/DynamicSchema.php
+++ b/src/Mongolid/DynamicSchema.php
@@ -4,7 +4,7 @@ namespace Mongolid;
 /**
  * The DynamicSchema will accept additional fields that are not specified in
  * the $schema property. This is usefull if you doesn't have a clear idea of how
- * tthe document will look like
+ * the document will look like
  *
  * @package  Mongolid
  */

--- a/src/Mongolid/Schema.php
+++ b/src/Mongolid/Schema.php
@@ -13,12 +13,12 @@ abstract class Schema
 {
     /**
      * The $dynamic property tells if the schema will accept additional fields
-     * that are not specified in the $schema property. This is usefull if you
+     * that are not specified in the $fields property. This is usefull if you
      * doesn't have a strict document format or if you want to take full
      * advantage of the "schemaless" nature of MongoDB.
      * @var boolean
      */
-    protected $dynamic = false;
+    public $dynamic = false;
 
     /**
      * Tells how a document should look like. If an scalar type is used, it will
@@ -26,12 +26,12 @@ abstract class Schema
      * the name of the method to be called. See 'mongoId' method for example.
      * @var string[]
      */
-    protected $schema  = [
+    public $fields  = [
         '_id' => 'mongoId' // Means that the _id will passtrought the `mongoId` method
     ];
 
     /**
-     * Filters any field in the $schema that has it's value specified as a
+     * Filters any field in the $fields that has it's value specified as a
      * 'mongoId'. It will wraps the $value, if any, into a MongoId object
      *
      * @param  mixed $value

--- a/src/Mongolid/Schema.php
+++ b/src/Mongolid/Schema.php
@@ -1,0 +1,49 @@
+<?php
+namespace Mongolid;
+
+use MongoId;
+
+/**
+ * A schema maps to a MongoDB collection and defines the shape of the documents
+ * within that collection.
+ *
+ * @package  Mongolid
+ */
+abstract class Schema
+{
+    /**
+     * The $dynamic property tells if the schema will accept additional fields
+     * that are not specified in the $schema property. This is usefull if you
+     * doesn't have a strict document format or if you want to take full
+     * advantage of the "schemaless" nature of MongoDB.
+     * @var boolean
+     */
+    protected $dynamic = false;
+
+    /**
+     * Tells how a document should look like. If an scalar type is used, it will
+     * perform a cast into the value. Othewise the schema will use the type as
+     * the name of the method to be called. See 'mongoId' method for example.
+     * @var string[]
+     */
+    protected $schema  = [
+        '_id' => 'mongoId' // Means that the _id will passtrought the `mongoId` method
+    ];
+
+    /**
+     * Filters any field in the $schema that has it's value specified as a
+     * 'mongoId'. It will wraps the $value, if any, into a MongoId object
+     *
+     * @param  mixed $value
+     *
+     * @return MongoId
+     */
+    public function mongoId($value = null)
+    {
+        if (! $value instanceof MongoId) {
+            $value = new MongoId($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Mongolid/Schema.php
+++ b/src/Mongolid/Schema.php
@@ -31,6 +31,13 @@ abstract class Schema
     ];
 
     /**
+     * Name of the class that will be used to represent a document of this
+     * Schema when retrieve from the database.
+     * @var string
+     */
+    public $entityClass = 'stdClass';
+
+    /**
      * Filters any field in the $fields that has it's value specified as a
      * 'mongoId'. It will wraps the $value, if any, into a MongoId object
      *

--- a/tests/Mongolid/Connection/PoolTest.php
+++ b/tests/Mongolid/Connection/PoolTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Mongolid\Connection;
+
+use TestCase;
+use Mockery as m;
+use Mongolid\Container\Ioc;
+
+class PoolTest extends TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testShouldGetAConnectionFromPoolIfContainsAny()
+    {
+        // Arrange
+        $pool       = new Pool;
+        $connQueue  = m::mock();
+        $connection = m::mock('Mongolid\Connection\Connection');
+        $this->setProtected($pool, 'connections', $connQueue);
+
+        // Act
+        $connQueue->shouldReceive('pop')
+            ->once()
+            ->andReturn($connection);
+
+        $connQueue->shouldReceive('push')
+            ->once()
+            ->with($connection);
+
+        // Assert
+        $this->assertEquals($connection, $pool->getConnection());
+    }
+
+    public function testShouldGetNullConnectionFromPoolIfItsEmpty()
+    {
+        // Arrange
+        $pool       = new Pool;
+        $connQueue  = m::mock();
+        $this->setProtected($pool, 'connections', $connQueue);
+
+        // Act
+        $connQueue->shouldReceive('pop')
+            ->once()
+            ->andReturn(null);
+
+        $connQueue->shouldReceive('push')
+            ->never();
+
+        // Assert
+        $this->assertNull($pool->getConnection());
+    }
+
+    public function testShouldAddConnectionToPool()
+    {
+        // Arrange
+        $pool       = new Pool;
+        $connQueue  = m::mock();
+        $connection = m::mock('Mongolid\Connection\Connection');
+        $this->setProtected($pool, 'connections', $connQueue);
+
+        // Act
+        $connQueue->shouldReceive('push')
+            ->once()
+            ->with($connection);
+
+        // Assert
+        $this->assertTrue($pool->addConnection($connection));
+    }
+}

--- a/tests/Mongolid/DataMapper/DataMapperTest.php
+++ b/tests/Mongolid/DataMapper/DataMapperTest.php
@@ -236,6 +236,21 @@ class DataMapperTest extends TestCase
             $this->callProtected($mapper, 'parseToArray', $object)
         );
     }
+
+    public function testShouldParseToArrayGettingObjectAttributes()
+    {
+        // Arrange
+        $mapper = new DataMapper;
+        $object = m::mock();
+        $object->foo  = 'bar';
+        $object->name = 'wilson';
+
+        // Assert
+        $this->assertEquals(
+            ['foo' => 'bar', 'name' => 'wilson'],
+            $this->callProtected($mapper, 'parseToArray', $object)
+        );
+    }
 }
 
 class __entity_stub {

--- a/tests/Mongolid/DataMapper/DataMapperTest.php
+++ b/tests/Mongolid/DataMapper/DataMapperTest.php
@@ -1,0 +1,243 @@
+<?php
+namespace Mongolid\DataMapper;
+
+use TestCase;
+use Mockery as m;
+use Mongolid\Container\Ioc;
+
+class DataMapperTest extends TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testShouldSave()
+    {
+        // Arrange
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performCommand]');
+        $object = m::mock();
+        $parsedObject = m::mock();
+
+        // Act
+        $mapper->shouldAllowMockingProtectedMethods();
+
+        $mapper->shouldReceive('parseToDocument')
+            ->once()
+            ->with($object)
+            ->andReturn($parsedObject);
+
+        $mapper->shouldReceive('performCommand')
+            ->once()
+            ->with('upsert', 'mongolid', $parsedObject)
+            ->andReturn(true);
+
+        // Assert
+        $this->assertTrue($mapper->save($object));
+    }
+
+    public function testShouldInsert()
+    {
+        // Arrange
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performCommand]');
+        $object = m::mock();
+        $parsedObject = m::mock();
+
+        // Act
+        $mapper->shouldAllowMockingProtectedMethods();
+
+        $mapper->shouldReceive('parseToDocument')
+            ->once()
+            ->with($object)
+            ->andReturn($parsedObject);
+
+        $mapper->shouldReceive('performCommand')
+            ->once()
+            ->with('insert', 'mongolid', $parsedObject)
+            ->andReturn(true);
+
+        // Assert
+        $this->assertTrue($mapper->insert($object));
+    }
+
+    public function testShouldUpdate()
+    {
+        // Arrange
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performCommand]');
+        $object = m::mock();
+        $parsedObject = m::mock();
+
+        // Act
+        $mapper->shouldAllowMockingProtectedMethods();
+
+        $mapper->shouldReceive('parseToDocument')
+            ->once()
+            ->with($object)
+            ->andReturn($parsedObject);
+
+        $mapper->shouldReceive('performCommand')
+            ->once()
+            ->with('update', 'mongolid', $parsedObject)
+            ->andReturn(true);
+
+        // Assert
+        $this->assertTrue($mapper->update($object));
+    }
+
+    public function testShouldGetWithWhereQuery()
+    {
+        // Arrange
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[getSchemaMapper,performCommand]');
+        $rawCursor      = m::mock('MongoCursor');
+        $mongolidCursor = m::mock('Mongolid\Cursor\Cursor');
+        $schemaMapper   = m::mock();
+        $query          = ['foo' => 'bar'];
+        $test           = $this;
+
+        $schemaMapper->entityClass = 'stdClass';
+
+        // Act
+        $mapper->shouldAllowMockingProtectedMethods();
+
+        $mapper->shouldReceive('getSchemaMapper')
+            ->once()
+            ->andReturn($schemaMapper);
+
+        $mapper->shouldReceive('performCommand')
+            ->once()
+            ->with('where', 'mongolid', $query)
+            ->andReturn($rawCursor);
+
+        // Binds a closure that will assert if the constructor params of Cursor are correct
+        Ioc::bind('Mongolid\Cursor\Cursor', function ($container, $params) use ($test, $rawCursor, $mongolidCursor) {
+            $test->assertEquals($rawCursor, $params[0]);
+            $test->assertEquals('stdClass', $params[1]);
+            return $mongolidCursor;
+        });
+
+        // Assert
+        $this->assertEquals(
+            $mongolidCursor,
+            $mapper->where($query)
+        );
+    }
+
+    public function testShouldGetAll()
+    {
+        // Arrange
+        $mapper         = m::mock('Mongolid\DataMapper\DataMapper[where]');
+        $mongolidCursor = m::mock('Mongolid\Cursor\Cursor');
+
+        // Act
+        $mapper->shouldReceive('where')
+            ->once()
+            ->with([])
+            ->andReturn($mongolidCursor);
+
+        // Assert
+        $this->assertEquals(
+            $mongolidCursor,
+            $mapper->all()
+        );
+    }
+
+    public function testShouldGetFirstWithQuery()
+    {
+        // Arrange
+        $mapper         = m::mock('Mongolid\DataMapper\DataMapper[where]');
+        $mongolidCursor = m::mock('Mongolid\Cursor\Cursor');
+        $query          = ['foo' => 'bar'];
+
+        // Act
+        $mapper->shouldReceive('where')
+            ->once()
+            ->with($query)
+            ->andReturn($mongolidCursor);
+
+        $mongolidCursor->shouldReceive('limit')
+            ->once()
+            ->with(1)
+            ->andReturn($mongolidCursor);
+
+        $mongolidCursor->shouldReceive('first')
+            ->once()
+            ->andReturn($mongolidCursor);
+
+        // Assert
+        $this->assertEquals(
+            $mongolidCursor,
+            $mapper->first($query)
+        );
+    }
+
+    public function testShouldParseObjectToDocument()
+    {
+        // Arrange
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[getSchemaMapper,parseToArray]');
+        $object         = m::mock();
+        $parsedDocument = ['a_field' => 123];
+        $schemaMapper   = m::mock();
+
+        // Act
+        $mapper->shouldAllowMockingProtectedMethods();
+
+        $mapper->shouldReceive('getSchemaMapper')
+            ->once()
+            ->andReturn($schemaMapper);
+
+        $mapper->shouldReceive('parseToArray')
+            ->once()
+            ->with($object)
+            ->andReturn(['a_field' => '123']);
+
+        $schemaMapper->shouldReceive('map')
+            ->once()
+            ->with(['a_field' => '123'])
+            ->andReturn($parsedDocument);
+
+        // Assert
+        $this->assertEquals(
+            $parsedDocument,
+            $this->callProtected($mapper, 'parseToDocument', $object)
+        );
+    }
+
+    public function testShouldGetSchemaMapper()
+    {
+        // Arrange
+        $mapper = new DataMapper;
+        $mapper->schemaClass = 'MySchema';
+        $schema = m::mock('Mongolid\Schema');
+
+        // Act
+        Ioc::instance('MySchema', $schema);
+
+        // Assert
+        $result = $this->callProtected($mapper, 'getSchemaMapper');
+        $this->assertInstanceOf('Mongolid\DataMapper\SchemaMapper', $result);
+        $this->assertEquals($schema, $result->schema);
+    }
+
+    public function testShouldParseToArrayWhenToArrayMethodIsAvailable()
+    {
+        // Arrange
+        $mapper = new DataMapper;
+        $object = m::mock(new __entity_stub);
+
+        // Act
+        $object->shouldReceive('toArray')
+            ->once()
+            ->andReturn(['foo' => 'bar']);
+
+        // Assert
+        $this->assertEquals(
+            ['foo' => 'bar'],
+            $this->callProtected($mapper, 'parseToArray', $object)
+        );
+    }
+}
+
+class __entity_stub {
+    public function toArray() {}
+}

--- a/tests/Mongolid/DataMapper/DataMapperTest.php
+++ b/tests/Mongolid/DataMapper/DataMapperTest.php
@@ -16,7 +16,7 @@ class DataMapperTest extends TestCase
     public function testShouldSave()
     {
         // Arrange
-        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performCommand]');
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performQuery]');
         $object = m::mock();
         $parsedObject = m::mock();
 
@@ -28,7 +28,7 @@ class DataMapperTest extends TestCase
             ->with($object)
             ->andReturn($parsedObject);
 
-        $mapper->shouldReceive('performCommand')
+        $mapper->shouldReceive('performQuery')
             ->once()
             ->with('upsert', 'mongolid', $parsedObject)
             ->andReturn(true);
@@ -40,7 +40,7 @@ class DataMapperTest extends TestCase
     public function testShouldInsert()
     {
         // Arrange
-        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performCommand]');
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performQuery]');
         $object = m::mock();
         $parsedObject = m::mock();
 
@@ -52,7 +52,7 @@ class DataMapperTest extends TestCase
             ->with($object)
             ->andReturn($parsedObject);
 
-        $mapper->shouldReceive('performCommand')
+        $mapper->shouldReceive('performQuery')
             ->once()
             ->with('insert', 'mongolid', $parsedObject)
             ->andReturn(true);
@@ -64,7 +64,7 @@ class DataMapperTest extends TestCase
     public function testShouldUpdate()
     {
         // Arrange
-        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performCommand]');
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[parseToDocument,performQuery]');
         $object = m::mock();
         $parsedObject = m::mock();
 
@@ -76,7 +76,7 @@ class DataMapperTest extends TestCase
             ->with($object)
             ->andReturn($parsedObject);
 
-        $mapper->shouldReceive('performCommand')
+        $mapper->shouldReceive('performQuery')
             ->once()
             ->with('update', 'mongolid', $parsedObject)
             ->andReturn(true);
@@ -88,7 +88,7 @@ class DataMapperTest extends TestCase
     public function testShouldGetWithWhereQuery()
     {
         // Arrange
-        $mapper = m::mock('Mongolid\DataMapper\DataMapper[getSchemaMapper,performCommand]');
+        $mapper = m::mock('Mongolid\DataMapper\DataMapper[getSchemaMapper,performQuery]');
         $rawCursor      = m::mock('MongoCursor');
         $mongolidCursor = m::mock('Mongolid\Cursor\Cursor');
         $schemaMapper   = m::mock();
@@ -104,7 +104,7 @@ class DataMapperTest extends TestCase
             ->once()
             ->andReturn($schemaMapper);
 
-        $mapper->shouldReceive('performCommand')
+        $mapper->shouldReceive('performQuery')
             ->once()
             ->with('where', 'mongolid', $query)
             ->andReturn($rawCursor);
@@ -249,6 +249,30 @@ class DataMapperTest extends TestCase
         $this->assertEquals(
             ['foo' => 'bar', 'name' => 'wilson'],
             $this->callProtected($mapper, 'parseToArray', $object)
+        );
+    }
+
+    public function testShouldPerformQuery()
+    {
+        // Arrange
+        $mapper     = new DataMapper;
+        $queryObj   = m::mock();
+        $collection = 'mongolid';
+        $param      = ['foo' => 'bar'];
+        $result     = 'result';
+
+        // Act
+        Ioc::instance('Mongolid\DataMapper\Query', $queryObj);
+
+        $queryObj->shouldReceive('thaCommand')
+            ->with('mongolid', $param)
+            ->once()
+            ->andReturn($result);
+
+        // Assert
+        $this->assertEquals(
+            $result,
+            $this->callProtected($mapper, 'performQuery', ['thaCommand', $collection, $param])
         );
     }
 }

--- a/tests/Mongolid/DataMapper/SchemaMapperTest.php
+++ b/tests/Mongolid/DataMapper/SchemaMapperTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace Mongolid\DataMapper;
+
+use TestCase;
+use Mockery as m;
+use Mongolid\Container\Ioc;
+
+class SchemaMapperTest extends TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testShouldMapToFieldsOfSchema()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+        $schema->fields = [
+            'name'  => 'string',
+            'age'   => 'int',
+            'stuff' => 'schema.My\Own\Schema'
+        ];
+        $schemaMapper = m::mock(
+            'Mongolid\DataMapper\SchemaMapper'.
+            '[parseDynamicAttributes,parseField]',
+            [$schema]
+        );
+        $schemaMapper->shouldAllowMockingProtectedMethods();
+        $data = [
+            'name'  => 'John',
+            'age'   => 23,
+            'stuff' => 'fooBar'
+        ];
+
+        // Act
+        $schemaMapper->shouldReceive('parseDynamicAttributes')
+            ->once()
+            ->with($data);
+
+        foreach($schema->fields as $key => $value) {
+            $schemaMapper->shouldReceive('parseField')
+                ->once()
+                ->with($data[$key], $value)
+                ->andReturn($data[$key].'.PARSED');
+        }
+
+        // Assert
+        $this->assertEquals(
+            [
+                'name'  => 'John.PARSED',
+                'age'   => '23.PARSED',
+                'stuff' => 'fooBar.PARSED'
+            ],
+            $schemaMapper->map($data)
+        );
+    }
+}

--- a/tests/Mongolid/DataMapper/SchemaMapperTest.php
+++ b/tests/Mongolid/DataMapper/SchemaMapperTest.php
@@ -24,7 +24,7 @@ class SchemaMapperTest extends TestCase
         ];
         $schemaMapper = m::mock(
             'Mongolid\DataMapper\SchemaMapper'.
-            '[parseDynamicAttributes,parseField]',
+            '[clearDynamic,parseField]',
             [$schema]
         );
         $schemaMapper->shouldAllowMockingProtectedMethods();
@@ -35,7 +35,7 @@ class SchemaMapperTest extends TestCase
         ];
 
         // Act
-        $schemaMapper->shouldReceive('parseDynamicAttributes')
+        $schemaMapper->shouldReceive('clearDynamic')
             ->once()
             ->with($data);
 
@@ -54,6 +54,172 @@ class SchemaMapperTest extends TestCase
                 'stuff' => 'fooBar.PARSED'
             ],
             $schemaMapper->map($data)
+        );
+    }
+
+    public function testShouldClearDynamicFieldsIfSchemaIsNotDynamic()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+        $schema->dynamic = false;
+        $schema->fields = [
+            'name'  => 'string',
+            'age'   => 'int',
+        ];
+        $schemaMapper = new SchemaMapper($schema);
+        $data = [
+            'name'     => 'John',
+            'age'      => 23,
+            'location' => 'Brazil'
+        ];
+
+        // Assert
+        $this->callProtected($schemaMapper, 'clearDynamic', [&$data]);
+        $this->assertEquals(
+            [
+                'name' => 'John',
+                'age'  => 23
+            ],
+            $data
+        );
+    }
+
+    public function testShouldNotClearDynamicFieldsIfSchemaIsDynamic()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+        $schema->dynamic = true;
+        $schema->fields = [
+            'name'  => 'string',
+            'age'   => 'int',
+        ];
+        $schemaMapper = new SchemaMapper($schema);
+        $data = [
+            'name'     => 'John',
+            'age'      => 23,
+            'location' => 'Brazil'
+        ];
+
+        // Assert
+        $this->callProtected($schemaMapper, 'clearDynamic', [&$data]);
+        $this->assertEquals(
+            [
+                'name'     => 'John',
+                'age'      => 23,
+                'location' => 'Brazil'
+            ],
+            $data
+        );
+    }
+
+    public function testShouldParseFieldIntoCastableType()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+        $schemaMapper = new SchemaMapper($schema);
+
+        // Assert
+        $this->assertSame(
+            23,
+            $schemaMapper->parseField('23', 'int')
+        );
+
+        $this->assertSame(
+            '1234',
+            $schemaMapper->parseField(1234, 'string')
+        );
+    }
+
+    public function testShouldParseFieldIntoAnotherMappedSchemaIfTypeBeginsWithSchema()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+        $schemaMapper = m::mock(
+            'Mongolid\DataMapper\SchemaMapper'.
+            '[mapToSchema]',
+            [$schema]
+        );
+        $schemaMapper->shouldAllowMockingProtectedMethods();
+
+        // Act
+        $schemaMapper->shouldReceive('mapToSchema')
+            ->once()
+            ->with(['foo' => 'bar'], 'FooBarSchema')
+            ->andReturn(['foo' => 123]);
+
+        // Assert
+        $this->assertSame(
+            ['foo' => 123],
+            $schemaMapper->parseField(['foo' => 'bar'], 'schema.FooBarSchema')
+        );
+    }
+
+    public function testShouldParseFieldUsingAMethodInSchemaIfTypeIsAnUnknowString()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[pumpkinPoint]');
+        $schemaMapper = new SchemaMapper($schema);
+
+        // Act
+        $schema->shouldReceive('pumpkinPoint')
+            ->once()
+            ->with(3)
+            ->andReturn(6);
+
+        // Assert
+        $this->assertSame(
+            6,
+            $schemaMapper->parseField(3, 'pumpkinPoint')
+        );
+    }
+
+    public function testShouldMapAnArrayValueToAnotherSchemaSchema()
+    {
+        // Arrange
+        $schema        = m::mock('Mongolid\Schema[]');
+        $mySchema      = m::mock('Mongolid\Schema[]');
+        $schemaMapper  = new SchemaMapper($schema);
+        $value         = ['foo' => 'bar'];
+        $test          = $this;
+
+        // Act
+        Ioc::instance('Xd\MySchema', $mySchema); // Register MySchema in Ioc
+
+        // When instantiating the SchemaMapper with the specified $param as dependency
+        Ioc::bind('Mongolid\DataMapper\SchemaMapper', function ($container, $params) use ($value, $mySchema, $test) {
+            // Check if mySchema has been injected correctly
+            $test->assertSame($mySchema, $params[0]);
+
+            // Instantiate a SchemaMapper with mySchema
+            $anotherSchemaMapper = m::mock('Mongolid\DataMapper\SchemaMapper', [$params[0]]);
+
+            // Set expectation to receiva a map call
+            $anotherSchemaMapper->shouldReceive('map')
+                ->once()
+                ->with($value)
+                ->andReturn(['foo' => 'PARSED']);
+
+            return $anotherSchemaMapper;
+        });
+
+        //Assert
+        $this->assertEquals(
+            ['foo' => 'PARSED'],
+            $this->callProtected($schemaMapper, 'mapToSchema', [$value, 'Xd\MySchema'])
+        );
+    }
+
+    public function testShouldMapNonArrayToNullWhenMappingToSchema()
+    {
+        // Arrange
+        $schema        = m::mock('Mongolid\Schema[]');
+        $schemaMapper  = new SchemaMapper($schema);
+        $value         = 4;
+
+        //Assert
+        $this->assertEquals(
+            null,
+            $this->callProtected($schemaMapper, 'mapToSchema', [$value, 'Xd\MySchema'])
         );
     }
 }

--- a/tests/Mongolid/DynamicSchemaTest.php
+++ b/tests/Mongolid/DynamicSchemaTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Mongolid;
+
+use TestCase;
+use Mockery as m;
+use Mongolid\Container\Ioc;
+
+class DynamicSchemaTest extends TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testShouldBeDynamic()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\DynamicSchema[]');
+
+        // Assert
+        $this->assertAttributeEquals(true, 'dynamic', $schema);
+    }
+}

--- a/tests/Mongolid/DynamicSchemaTest.php
+++ b/tests/Mongolid/DynamicSchemaTest.php
@@ -13,6 +13,15 @@ class DynamicSchemaTest extends TestCase
         m::close();
     }
 
+    public function testShouldExtendSchema()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\DynamicSchema[]');
+
+        // Assert
+        $this->assertInstanceOf('Mongolid\Schema', $schema);
+    }
+
     public function testShouldBeDynamic()
     {
         // Arrange

--- a/tests/Mongolid/SchemaTest.php
+++ b/tests/Mongolid/SchemaTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace Mongolid;
+
+use TestCase;
+use Mockery as m;
+use Mongolid\Container\Ioc;
+
+class SchemaTest extends TestCase
+{
+    public function tearDown()
+    {
+        parent::tearDown();
+        m::close();
+    }
+
+    public function testShouldNotBeDynamicByDefault()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+
+        // Assert
+        $this->assertAttributeEquals(false, 'dynamic', $schema);
+    }
+
+    public function testShouldCastNullIntoMongoId()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+        $value  = null;
+
+        // Assert
+        $this->assertInstanceOf(
+            'MongoId',
+            $schema->mongoId($value)
+        );
+    }
+
+    public function testShouldNotCastRandomStringIntoMongoId()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+        $value  = 'A random string';
+
+        // Act
+        $this->setExpectedException(
+          'MongoException', 'Invalid object ID'
+        );
+
+        // Assert
+        $schema->mongoId($value);
+    }
+
+    public function testShouldCastObjectIdStringIntoMongoId()
+    {
+        // Arrange
+        $schema = m::mock('Mongolid\Schema[]');
+        $value  = '507f1f77bcf86cd799439011';
+
+        // Assert
+        $this->assertInstanceOf(
+            'MongoId',
+            $schema->mongoId($value)
+        );
+
+        $this->assertEquals(
+            $value,
+            (string)$schema->mongoId($value)
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -34,4 +34,25 @@ class TestCase extends PHPUnit_Framework_TestCase
 
         return $methodObj->invokeArgs($obj, $args);
     }
+
+    /**
+     * Call a protected property of an object
+     *
+     * @param  mixed $obj
+     * @param  string $attribute Property name
+     * @param  mixed  $value Value to be set
+     */
+    protected function setProtected($obj, $property, $value)
+    {
+        $class = new ReflectionClass($obj);
+        $property = $class->getProperty($property);
+        $property->setAccessible(true);
+
+        if (is_string($obj)) { // static
+            $property->setValue($value);
+            return;
+        }
+
+        $property->setValue($obj, $value);
+    }
 }


### PR DESCRIPTION
The DataMapper should enable an optional non ActiveRecord usage.

Merge #30 first!

**EDIT:**

Currently the `--testdox` for the tests regarding this pull request are

```
Mongolid\Schema
A schema maps to a MongoDB collection and defines the shape of the documents
within that collection.
 [x] Should not be dynamic by default
 [x] Should cast null into mongo id
 [x] Should not cast random string into mongo id
 [x] Should cast object id string into mongo id

Mongolid\DynamicSchema
The DynamicSchema will accept additional fields that are not specified in
the $schema property. This is usefull if you doesn't have a clear idea of how
the document will look like
 [x] Should extend schema
 [x] Should be dynamic

Mongolid\DataMapper\DataMapper
The DataMapper class will abstract how an Entity is persisted and retrieved
from the database.
The DataMapper will always use a Schema trought the SchemaMapper to parse the
document in and out of the database.
 [x] Should save
 [x] Should insert
 [x] Should update
 [x] Should get with where query
 [x] Should get all
 [x] Should get first with query
 [x] Should parse object to document
 [x] Should get schema mapper
 [x] Should parse to array when to array method is available
 [x] Should perform query

Mongolid\DataMapper\SchemaMapper
The SchemaMapper will map an array of data to an Schema object. When
instantiating a SchemaMapper you should provide a Schema. When calling 'map'
the Schema provided will be used to format the data to the correct format.
 [x] Should map to fields of schema
 [x] Should clear dynamic fields if schema is not dynamic
 [x] Should not clear dynamic fields if schema is dynamic
 [x] Should parse field into castable type
 [x] Should parse field into another mapped schema if type begins with schema
 [x] Should parse field using a method in schema if type is an unknow string
 [x] Should map an array value to another schema schema
 [x] Should map non array to null when mapping to schema
 [x] Should map non array to null when mapping to schema
```