### PR TITLE
Remove array_flip on project fields allowing projects to work.

### DIFF
--- a/src/Zizaco/Mongolid/Model.php
+++ b/src/Zizaco/Mongolid/Model.php
@@ -441,7 +441,6 @@ class Model
     protected function prepareProjection($fields)
     {
         // Prepare fields array for mongo query
-        $fields = array_flip($fields);
         foreach ($fields as $field => $value) {
             $fields[$field] = 1;
         }


### PR DESCRIPTION
The array flip causes all the fields to come out as [1 => 1], I've removed this so the projections work.