### PR TITLE
Include mutators support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     ],
     "require": {
         "php": ">=7.0",
-        "mongodb/mongodb": "^1.0.0",
+        "mongodb/mongodb": "^1.0",
         "illuminate/container": "^5.0"
     },
     "require-dev": {
-        "mockery/mockery": "dev-master",
-        "satooshi/php-coveralls": "dev-master",
-        "phpunit/phpunit": "^4.0",
+        "mockery/mockery": "^0.9",
+        "satooshi/php-coveralls": "^1.0",
+        "phpunit/phpunit": "^5.0",
         "squizlabs/php_codesniffer": "^2.0"
     },
     "autoload": {
@@ -32,12 +32,5 @@
         "classmap": [
             "tests/TestCase.php"
         ]
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "v0.5-dev"
-        }
-    },
-
-    "minimum-stability": "dev"
+    }
 }

--- a/src/Mongolid/Model/Attributes.php
+++ b/src/Mongolid/Model/Attributes.php
@@ -20,12 +20,14 @@ trait Attributes
      * @var array
      */
     protected $attributes = [];
+    
     /**
      * The model attribute's original state.
      *
      * @var array
      */
     protected $original = [];
+    
     /**
      * Once you put at least one string in this array, only
      * the attributes especified here will be changed
@@ -34,6 +36,7 @@ trait Attributes
      * @var array
      */
     public $fillable = [];
+    
     /**
      * The attributes that aren't mass assignable. The oposite
      * to the fillable array;
@@ -41,7 +44,16 @@ trait Attributes
      * @var array
      */
     public $guarded = [];
-
+    
+    /**
+     * Check if model should mutate attributes checking
+     * the existence of a specific method on model
+     * class. Default is true.
+     *
+     * @var boolean
+     */
+    public $mutable = true;
+    
     /**
      * Get an attribute from the model.
      *
@@ -59,15 +71,6 @@ trait Attributes
         } else {
             return null;
         }
-    }
-    /**
-     * Get all attributes from the model.
-     *
-     * @return mixed
-     */
-    public function getAttributes()
-    {
-        return $this->attributes;
     }
 
     /**
@@ -95,6 +98,17 @@ trait Attributes
     {
         unset($this->attributes[$key]);
     }
+    
+    /**
+     * Get all attributes from the model.
+     *
+     * @return mixed
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+    
 
     /**
      * Set a given attribute on the model.
@@ -108,6 +122,29 @@ trait Attributes
     {
         $this->attributes[$key] = $value;
     }
+        
+    /**
+     * Verify if model has a mutator method defined.
+     *
+     * @return boolean
+     */
+    protected function hasMutatorMethod($key, $prefix)
+    {
+        $method = $this->buildMutatorMethod($key, $prefix);
+        
+        return method_exists($this, $method);
+    }
+    
+    /**
+     * Create mutator method pattern.
+     *
+     * @return string
+     */
+    protected function buildMutatorMethod($key, $prefix)
+    {
+        return $prefix . ucfirst($key) . 'Attribute';
+        
+    }
 
     /**
      * Dynamically retrieve attributes on the model.
@@ -118,8 +155,13 @@ trait Attributes
      */
     public function __get($key)
     {
+        if ($this->mutable && $this->hasMutatorMethod($key, 'get')){
+            return $this->{$this->buildMutatorMethod($key, 'get')}();
+        }
+        
         return $this->getAttribute($key);
     }
+    
     /**
      * Dynamically set attributes on the model.
      *
@@ -130,7 +172,10 @@ trait Attributes
      */
     public function __set($key, $value)
     {
-        // Set attribute
+        if ($this->mutable && $this->hasMutatorMethod($key, 'set')){
+            $value = $this->{$this->buildMutatorMethod($key, 'set')}($value);
+        }
+        
         $this->setAttribute($key, $value);
     }
 
@@ -145,6 +190,7 @@ trait Attributes
     {
         return isset($this->attributes[$key]);
     }
+    
     /**
      * Unset an attribute on the model.
      *

--- a/tests/Mongolid/Model/AttributesTest.php
+++ b/tests/Mongolid/Model/AttributesTest.php
@@ -17,7 +17,10 @@ class AttributesTest extends TestCase
     public function testShouldHaveDynamicSetters()
     {
         // Arrange
-        $model = new _stubAttributes;
+        $model = new class{ 
+            use Attributes; 
+        };
+        
         $childObj = new stdClass;
 
         // Assert
@@ -38,7 +41,10 @@ class AttributesTest extends TestCase
     public function testShouldHaveDynamicGetters()
     {
         // Arrange
-        $model = new _stubAttributes;
+        $model = new class{ 
+            use Attributes; 
+        };
+        
         $childObj = new stdClass;
         $this->setProtected(
             $model,
@@ -60,7 +66,10 @@ class AttributesTest extends TestCase
     public function testShouldCheckIfAttributeIsSet()
     {
         // Arrange
-        $model = new _stubAttributes;
+        $model = new class{ 
+            use Attributes; 
+        };
+        
         $this->setProtected(
             $model,
             'attributes',
@@ -75,7 +84,10 @@ class AttributesTest extends TestCase
     public function testShouldUnsetAttributes()
     {
         // Arrange
-        $model = new _stubAttributes;
+        $model = new class{ 
+            use Attributes; 
+        };
+        
         $this->setProtected(
             $model,
             'attributes',
@@ -95,6 +107,67 @@ class AttributesTest extends TestCase
             $model
         );
     }
+    
+    public function testShouldGetAttributeFromMutator()
+    {
+        // Arrange
+        $model = new class{ 
+            use Attributes;
+            
+            public function getSomeAttribute()
+            {
+                return 'something-else';
+            } 
+        };
+        
+        $model->some = 'some-value';
+        
+        // Assert        
+        $this->assertEquals('something-else', $model->some);
+    }
+    
+    public function testShouldIgnoreMutators()
+    {
+        // Arrange
+        $model = new class{ 
+            use Attributes;
+                                    
+            public function getSomeAttribute()
+            {
+                return 'something-else';
+            } 
+            
+            public function setSomeAttribute($value)
+            {
+                return strtoupper($value);
+            } 
+        };
+        
+        $this->setProtected($model, 'mutable', false);
+        
+        $model->some = 'some-value';
+        
+        // Assert        
+        $this->assertEquals('some-value', $model->some);
+    }
+    
+    public function testShouldSetAttributeFromMutator()
+    {
+        // Arrange
+        $model = new class{ 
+            use Attributes;
+            
+            public function setSomeAttribute($value)
+            {
+                return strtoupper($value);
+            } 
+        };
+        
+        $model->some = 'some-value';
+        
+        // Assert        
+        $this->assertEquals('SOME-VALUE', $model->some);
+    }
 
     /**
      * @dataProvider getFillableOptions
@@ -106,7 +179,10 @@ class AttributesTest extends TestCase
         $expected
     ) {
         // Arrange
-        $model = new _stubAttributes;
+        $model = new class{ 
+            use Attributes;
+        };
+        
         $this->setProtected($model, 'fillable', $fillable);
         $this->setProtected($model, 'guarded', $guarded);
 
@@ -178,8 +254,4 @@ class AttributesTest extends TestCase
             ],
         ];
     }
-}
-
-class _stubAttributes {
-    use Attributes;
 }


### PR DESCRIPTION
Include mutators support on Attributes trait.

One should declare something like this on his model and this methos will be triggered in `__set` or `__get` magic methods:

```
<?php

class MyModel extends Model {
    public function getSomeAttribute()
    {
        return 'something-else';
    } 
    
    public function setSomeAttribute($value)
    {
        return strtoupper($value);
    } 
}

$m = new MyModel();
$m->some = 'something';  // will store 'SOMETHING' on $attributes property
echo $m->some;  // will return 'something-else' from getSomeAttribute
```

Original atribute could be retrieved from `getAttribute` method and if you wish, mutator could be disabled setting `$mutable` to false.

Also, using anonymous classes on test.