### PR TITLE
Include mutators support

### DIFF
--- a/tests/Mongolid/Model/AttributesTest.php
+++ b/tests/Mongolid/Model/AttributesTest.php
@@ -108,6 +108,67 @@ class AttributesTest extends TestCase
         );
     }
 
+    public function testShouldGetAttributeFromMutator()
+    {
+        // Arrange
+        $model = new class{ 
+            use Attributes;
+            
+            public function getSomeAttribute()
+            {
+                return 'something-else';
+            } 
+        };
+        
+        $model->some = 'some-value';
+        
+        // Assert        
+        $this->assertEquals('something-else', $model->some);
+    }
+    
+    public function testShouldIgnoreMutators()
+    {
+        // Arrange
+        $model = new class{ 
+            use Attributes;
+                                    
+            public function getSomeAttribute()
+            {
+                return 'something-else';
+            } 
+            
+            public function setSomeAttribute($value)
+            {
+                return strtoupper($value);
+            } 
+        };
+        
+        /* Disable mutator methods */
+        $model->mutable = false;
+        $model->some = 'some-value';
+        
+        // Assert        
+        $this->assertEquals('some-value', $model->some);
+    }
+    
+    public function testShouldSetAttributeFromMutator()
+    {
+        // Arrange
+        $model = new class{ 
+            use Attributes;
+            
+            public function setSomeAttribute($value)
+            {
+                return strtoupper($value);
+            } 
+        };
+        
+        $model->some = 'some-value';
+        
+        // Assert        
+        $this->assertEquals('SOME-VALUE', $model->some);
+    }
+
     /**
      * @dataProvider getFillableOptions
      */


### PR DESCRIPTION

This make possible declare a method like the bellow on a model and this will be triggered in `__set` or `__get` magic methods:

```
<?php

class MyModel extends Model {
    public function getSomeAttribute()
    {
        return 'something-else';
    } 
    
    public function setSomeAttribute($value)
    {
        return strtoupper($value);
    } 
}

$m = new MyModel();
$m->some = 'something';  // will store 'SOMETHING' on $attributes property
echo $m->some;  // will return 'something-else' from getSomeAttribute
```

Original attribute could be retrieved directly from `getAttribute` method or mutator could be shut off by setting `$mutable` property to false.