### PR TITLE
Serializable ActiveRecord

### DIFF
--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -191,9 +191,9 @@ abstract class ActiveRecord implements Serializable
     }
 
     /**
-     * Serializes this object using custom Serializer class.
+     * {@inheritdoc}
      *
-     * @return string Serialized object.
+     * @return string
      */
     public function serialize()
     {
@@ -201,12 +201,11 @@ abstract class ActiveRecord implements Serializable
     }
 
     /**
-     * Unserializes the given string and transform it to a filled ActiveRecord
-     * implementation.
+     * {@inheritdoc}
      *
-     * @param  string $data String with serialized object.
+     * @param mixed $data Serialized string to parse.
      *
-     * @return ActiveRecord Unserialized object.
+     * @return void
      */
     public function unserialize($data)
     {

--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -7,6 +7,7 @@ use Mongolid\DataMapper\DataMapper;
 use Mongolid\Model\Attributes;
 use Mongolid\Model\Relations;
 use Mongolid\Schema;
+use Serializable;
 
 /**
  * The Mongolid\ActiveRecord base class will ensure to enable your entity to
@@ -17,7 +18,7 @@ use Mongolid\Schema;
  *
  * @package  Mongolid
  */
-abstract class ActiveRecord
+abstract class ActiveRecord implements Serializable
 {
     use Attributes, Relations;
 
@@ -186,6 +187,22 @@ abstract class ActiveRecord
     public function getCollectionName()
     {
         return $this->collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return Ioc::make(Serializer::class)->serialize($this->getAttributes());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($data)
+    {
+        return Ioc::make(Serializer::class)->unserialize($data);
     }
 
     /**

--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -191,7 +191,9 @@ abstract class ActiveRecord implements Serializable
     }
 
     /**
-     * {@inheritdoc}
+     * Serializes this object using custom Serializer class.
+     *
+     * @return string Serialized object.
      */
     public function serialize()
     {
@@ -199,7 +201,12 @@ abstract class ActiveRecord implements Serializable
     }
 
     /**
-     * {@inheritdoc}
+     * Unserializes the given string and transform it to a filled ActiveRecord
+     * implementation.
+     *
+     * @param  string $data String with serialized object.
+     *
+     * @return ActiveRecord Unserialized object.
      */
     public function unserialize($data)
     {

--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -203,7 +203,7 @@ abstract class ActiveRecord implements Serializable
      */
     public function unserialize($data)
     {
-        return Ioc::make(Serializer::class)->unserialize($data);
+        $this->fill(Ioc::make(Serializer::class)->unserialize($data), true);
     }
 
     /**

--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -179,6 +179,16 @@ abstract class ActiveRecord
     }
 
     /**
+     * Getter for the $collection attribute.
+     *
+     * @return string
+     */
+    public function getCollectionName()
+    {
+        return $this->collection;
+    }
+
+    /**
      * Returns a Schema object that describes this Entity in MongoDB
      *
      * @return Schema
@@ -227,15 +237,5 @@ abstract class ActiveRecord
         }
 
         return $this->getDataMapper()->$action($this);
-    }
-
-    /**
-     * Getter for the $collection attribute.
-     *
-     * @return string
-     */
-    public function getCollectionName()
-    {
-        return $this->collection;
     }
 }

--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -7,6 +7,7 @@ use Mongolid\DataMapper\DataMapper;
 use Mongolid\Model\Attributes;
 use Mongolid\Model\Relations;
 use Mongolid\Schema;
+use Mongolid\Serializer\Serializer;
 use Serializable;
 
 /**

--- a/src/Mongolid/Cursor/Cursor.php
+++ b/src/Mongolid/Cursor/Cursor.php
@@ -285,7 +285,8 @@ class Cursor implements Iterator, Serializable
     }
 
     /**
-     * Serializes this object using custom Serializer class.
+     * Serializes this object storing the collection name instead of the actual
+     * MongoDb\Collection (which is unserializable)
      *
      * @return string Serialized object.
      */
@@ -297,6 +298,13 @@ class Cursor implements Iterator, Serializable
         return serialize($properties);
     }
 
+    /**
+     * Unserializes this object. Re-creating the database connection.
+     *
+     * @param  mixed $serialized Serialized cursor.
+     *
+     * @return void
+     */
     public function unserialize($serialized)
     {
         $attr = unserialize($serialized);

--- a/src/Mongolid/Model/Relations.php
+++ b/src/Mongolid/Model/Relations.php
@@ -84,7 +84,7 @@ trait Relations
      * @param string $entity Class of the entity or of the schema of the entity.
      * @param string $field  Field where the embedded documents are stored.
      *
-     * @return array Array with the embedded documents
+     * @return EmbeddedCursor Array with the embedded documents
      */
     protected function embedsMany(string $entity, string $field)
     {

--- a/src/Mongolid/Serializer.php
+++ b/src/Mongolid/Serializer.php
@@ -1,0 +1,41 @@
+<?php
+namespace Mongolid;
+
+/**
+ * This class is responsible to serialize ActiveRecord classes. It's necessary
+ * due to a bug in Mongo Driver that doesn't allow us to serialize some classes,
+ * i.e., ObjectID, UTCDateTime
+ *
+ * It's a bug present in 1.1 version and should be fixed in version 1.2, so,
+ * this class can be deleted after upgrade our dependency of 1.1 version of
+ * MongoDB driver
+ *
+ * @see https://jira.mongodb.org/browse/PHPC-460
+ */
+class Serializer
+{
+    /**
+     * Walk into an array to get not serializable objects and convert it to a
+     * serializable one
+     *
+     * @param  array $attributes ActiveRecord attributes to be serialized
+     *
+     * @return string
+     */
+    public function serialize(array $attributes): string
+    {
+        return serialize($attributes);
+    }
+
+    /**
+     * Unserializes the given string and turn it back to specific objects
+     *
+     * @param  string $data Serialized string to be converted
+     *
+     * @return mixed
+     */
+    public function unserialize(string $data)
+    {
+        return unserialize($data);
+    }
+}

--- a/src/Mongolid/Serializer/SerializableTypeInterface.php
+++ b/src/Mongolid/Serializer/SerializableTypeInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace Mongolid\Serializer;
+
+use Serializable;
+
+/**
+ * This interface is a contract to convert unserialized objects to corresponding
+ * MongoDB\BSON objects
+ */
+interface SerializableTypeInterface extends Serializable
+{
+    /**
+     * Retrieves corresponding MongoDB object that according to class that
+     * implement this interface, i.e., Type\ObjectID should return an
+     * MongoDB\BSON\ObjectID object
+     *
+     * @return mixed
+     */
+    public function convert();
+}

--- a/src/Mongolid/Serializer/Serializer.php
+++ b/src/Mongolid/Serializer/Serializer.php
@@ -1,5 +1,5 @@
 <?php
-namespace Mongolid;
+namespace Mongolid\Serializer;
 
 /**
  * This class is responsible to serialize ActiveRecord classes. It's necessary

--- a/src/Mongolid/Serializer/Serializer.php
+++ b/src/Mongolid/Serializer/Serializer.php
@@ -38,9 +38,9 @@ class Serializer
 
     /**
      * Walk into an array to get not serializable objects and replace it by a
-     * serializable one
+     * serializable one.
      *
-     * @param  array $attributes ActiveRecord attributes to be serialized
+     * @param  array $attributes ActiveRecord attributes to be serialized.
      *
      * @return string
      */
@@ -57,9 +57,9 @@ class Serializer
     }
 
     /**
-     * Unserializes the given string and turn it back to specific objects
+     * Unserializes the given string and turn it back to specific objects.
      *
-     * @param  string $data Serialized string to be converted
+     * @param  string $data Serialized string to be converted.
      *
      * @return array
      */
@@ -76,9 +76,9 @@ class Serializer
     }
 
     /**
-     * Checks if the given parameter is a mapped type and return its index
+     * Checks if the given parameter is a mapped type and return its index.
      *
-     * @param  mixed $value Value of array to check
+     * @param  mixed $value Value of array to check.
      *
      * @return boolean|integer
      */

--- a/src/Mongolid/Serializer/Type/ObjectID.php
+++ b/src/Mongolid/Serializer/Type/ObjectID.php
@@ -17,7 +17,7 @@ class ObjectID implements SerializableTypeInterface
     /**
      * Constructor
      *
-     * @param MongoObjectID $mongoId MongoDB ObjectID to serialize
+     * @param MongoObjectID $mongoId MongoDB ObjectID to serialize.
      */
     public function __construct(MongoObjectID $mongoId)
     {
@@ -25,7 +25,9 @@ class ObjectID implements SerializableTypeInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Serialies string of ObjectID
+     *
+     * @return string Serialized id
      */
     public function serialize()
     {
@@ -33,7 +35,11 @@ class ObjectID implements SerializableTypeInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Unserializes the object id string
+     *
+     * @param  string $data Serialized object id.
+     *
+     * @return void
      */
     public function unserialize($data)
     {

--- a/src/Mongolid/Serializer/Type/ObjectID.php
+++ b/src/Mongolid/Serializer/Type/ObjectID.php
@@ -1,0 +1,50 @@
+<?php
+namespace Mongolid\Serializer\Type;
+
+use MongoDB\BSON\ObjectID as MongoObjectID;
+use Mongolid\Serializer\SerializableTypeInterface;
+
+/**
+ * This class is a workaround to make real Mongo ObjectID serializable
+ */
+class ObjectID implements SerializableTypeInterface
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * Constructor
+     *
+     * @param MongoObjectID $mongoId MongoDB ObjectID to serialize
+     */
+    public function __construct(MongoObjectID $mongoId)
+    {
+        $this->id = (string) $mongoId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize($this->id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($data)
+    {
+        $this->id = unserialize($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convert()
+    {
+        return new MongoObjectID($this->id);
+    }
+}

--- a/src/Mongolid/Serializer/Type/ObjectID.php
+++ b/src/Mongolid/Serializer/Type/ObjectID.php
@@ -25,9 +25,9 @@ class ObjectID implements SerializableTypeInterface
     }
 
     /**
-     * Serialies string of ObjectID
+     * {@inheritdoc}
      *
-     * @return string Serialized id
+     * @return string
      */
     public function serialize()
     {
@@ -35,9 +35,9 @@ class ObjectID implements SerializableTypeInterface
     }
 
     /**
-     * Unserializes the object id string
+     * {@inheritdoc}
      *
-     * @param  string $data Serialized object id.
+     * @param mixed $data Serialized string to parse.
      *
      * @return void
      */
@@ -48,6 +48,8 @@ class ObjectID implements SerializableTypeInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return MongoObjectID
      */
     public function convert()
     {

--- a/src/Mongolid/Serializer/Type/UTCDateTime.php
+++ b/src/Mongolid/Serializer/Type/UTCDateTime.php
@@ -18,7 +18,7 @@ class UTCDateTime implements SerializableTypeInterface
     /**
      * Constructor
      *
-     * @param MongoUTCDateTime $mongoDate Object to convert
+     * @param MongoUTCDateTime $mongoDate Object to convert.
      */
     public function __construct(MongoUTCDateTime $mongoDate)
     {
@@ -26,7 +26,7 @@ class UTCDateTime implements SerializableTypeInterface
     }
 
     /**
-     * Serializes converted date.
+     * {@inheritdoc}
      *
      * @return string
      */
@@ -36,9 +36,9 @@ class UTCDateTime implements SerializableTypeInterface
     }
 
     /**
-     * Unserializes the given data
+     * {@inheritdoc}
      *
-     * @param string $data Converted string date
+     * @param mixed $data Serialized string to parse.
      *
      * @return void
      */
@@ -49,6 +49,8 @@ class UTCDateTime implements SerializableTypeInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return MongoUTCDateTime
      */
     public function convert()
     {

--- a/src/Mongolid/Serializer/Type/UTCDateTime.php
+++ b/src/Mongolid/Serializer/Type/UTCDateTime.php
@@ -15,13 +15,20 @@ class UTCDateTime implements SerializableTypeInterface
      */
     protected $date;
 
+    /**
+     * Constructor
+     *
+     * @param MongoUTCDateTime $mongoDate Object to convert
+     */
     public function __construct(MongoUTCDateTime $mongoDate)
     {
         $this->date = $mongoDate->toDateTime()->format('Y-m-d H:i:s');
     }
 
     /**
-     * {@inheritdoc}
+     * Serializes converted date.
+     *
+     * @return string
      */
     public function serialize()
     {
@@ -29,7 +36,11 @@ class UTCDateTime implements SerializableTypeInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Unserializes the given data
+     *
+     * @param string $data Converted string date
+     *
+     * @return void
      */
     public function unserialize($data)
     {

--- a/src/Mongolid/Serializer/Type/UTCDateTime.php
+++ b/src/Mongolid/Serializer/Type/UTCDateTime.php
@@ -1,0 +1,48 @@
+<?php
+namespace Mongolid\Serializer\Type;
+
+use DateTime;
+use MongoDB\BSON\UTCDateTime as MongoUTCDateTime;
+use Mongolid\Serializer\SerializableTypeInterface;
+
+/**
+ * This class is a workaround to make real Mongo UTCDateTime serializable
+ */
+class UTCDateTime implements SerializableTypeInterface
+{
+    /**
+     * @var string
+     */
+    protected $date;
+
+    public function __construct(MongoUTCDateTime $mongoDate)
+    {
+        $this->date = $mongoDate->toDateTime()->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize($this->date);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($data)
+    {
+        $this->date = unserialize($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convert()
+    {
+        $date = DateTime::createFromFormat('Y-m-d H:i:s', $this->date);
+
+        return new MongoUTCDateTime($date->getTimestamp()*1000);
+    }
+}

--- a/tests/Mongolid/ActiveRecordTest.php
+++ b/tests/Mongolid/ActiveRecordTest.php
@@ -10,17 +10,33 @@ use TestCase;
 
 class ActiveRecordTest extends TestCase
 {
+    /**
+     * @var ActiveRecord
+     */
+    protected $entity;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->entity = new class extends ActiveRecord {
+        };
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function tearDown()
     {
         parent::tearDown();
         m::close();
+        unset($this->entity);
     }
 
     public function testShouldHaveCorrectPropertiesByDefault()
     {
-        // Arrage
-        $entity = m::mock(ActiveRecord::class.'[]');
-
         // Assert
         $this->assertAttributeEquals(
             [
@@ -29,9 +45,9 @@ class ActiveRecordTest extends TestCase
                 'updated_at' => 'updatedAtTimestamp'
             ],
             'fields',
-            $entity
+            $this->entity
         );
-        $this->assertTrue($entity->dynamic);
+        $this->assertTrue($this->entity->dynamic);
     }
 
     public function testShouldImplementModelTraits()
@@ -133,26 +149,22 @@ class ActiveRecordTest extends TestCase
 
     public function testSaveShouldReturnFalseIfCollectionIsNull()
     {
-        $entity = m::mock(ActiveRecord::class)->makePartial();
-        $this->assertFalse($entity->save());
+        $this->assertFalse($this->entity->save());
     }
 
     public function testUpdateShouldReturnFalseIfCollectionIsNull()
     {
-        $entity = m::mock(ActiveRecord::class)->makePartial();
-        $this->assertFalse($entity->update());
+        $this->assertFalse($this->entity->update());
     }
 
     public function testInsertShouldReturnFalseIfCollectionIsNull()
     {
-        $entity = m::mock(ActiveRecord::class)->makePartial();
-        $this->assertFalse($entity->insert());
+        $this->assertFalse($this->entity->insert());
     }
 
     public function testDeleteShouldReturnFalseIfCollectionIsNull()
     {
-        $entity = m::mock(ActiveRecord::class)->makePartial();
-        $this->assertFalse($entity->delete());
+        $this->assertFalse($this->entity->delete());
     }
 
     public function testShouldGetWithWhereQuery()
@@ -225,31 +237,32 @@ class ActiveRecordTest extends TestCase
     public function testShouldGetSchemaIfFieldsIsTheClassName()
     {
         // Arrage
-        $entity = m::mock(ActiveRecord::class.'[]');
-        $this->setProtected($entity, 'fields', 'MySchemaClass');
+        $this->setProtected($this->entity, 'fields', 'MySchemaClass');
         $schema = m::mock(Schema::class);
 
         // Act
         Ioc::instance('MySchemaClass', $schema);
 
         // Assert
-        $this->assertEquals($schema, $this->callProtected($entity, 'getSchema'));
+        $this->assertEquals(
+            $schema,
+            $this->callProtected($this->entity, 'getSchema')
+        );
     }
 
     public function testShouldGetSchemaIfFieldsDescribesSchemaFields()
     {
         // Arrage
-        $entity = m::mock(ActiveRecord::class.'[]');
         $fields = ['name' => 'string', 'age' => 'int'];
-        $this->setProtected($entity, 'fields', $fields);
+        $this->setProtected($this->entity, 'fields', $fields);
 
         // Assert
-        $result = $this->callProtected($entity, 'getSchema');
+        $result = $this->callProtected($this->entity, 'getSchema');
         $this->assertInstanceOf(Schema::class, $result);
         $this->assertEquals($fields, $result->fields);
-        $this->assertEquals($entity->dynamic, $result->dynamic);
-        $this->assertEquals($entity->getCollectionName(), $result->collection);
-        $this->assertEquals(get_class($entity), $result->entityClass);
+        $this->assertEquals($this->entity->dynamic, $result->dynamic);
+        $this->assertEquals($this->entity->getCollectionName(), $result->collection);
+        $this->assertEquals(get_class($this->entity), $result->entityClass);
     }
 
     public function testShouldGetDataMapper()

--- a/tests/Mongolid/ActiveRecordTest.php
+++ b/tests/Mongolid/ActiveRecordTest.php
@@ -6,6 +6,7 @@ use Mongolid\Container\Ioc;
 use Mongolid\Model\Attributes;
 use Mongolid\Model\Relations;
 use Mongolid\Schema;
+use Mongolid\Serializer\Serializer;
 use Serializable;
 use TestCase;
 

--- a/tests/Mongolid/ActiveRecordTest.php
+++ b/tests/Mongolid/ActiveRecordTest.php
@@ -319,10 +319,10 @@ class ActiveRecordTest extends TestCase
         );
     }
 
-    public function testUnderializeShouldCallSerializerAndReturnAnArray()
+    public function testUnderializeShouldCallSerializerAndFillObjectSuccessfully()
     {
         $serializer = m::mock(Serializer::class);
-        $attributes = ['some', 'attributes'];
+        $attributes = ['some' => 'attributes'];
 
         $serializer->shouldReceive('unserialize')
             ->with('some-serialized-string')
@@ -331,9 +331,8 @@ class ActiveRecordTest extends TestCase
 
         Ioc::instance(Serializer::class, $serializer);
 
-        $this->assertEquals(
-            $attributes,
-            $this->entity->unserialize('some-serialized-string')
-        );
+        $this->entity->unserialize('some-serialized-string');
+
+        $this->assertEquals($attributes, $this->entity->getAttributes());
     }
 }

--- a/tests/Mongolid/Serializer/SerializerTest.php
+++ b/tests/Mongolid/Serializer/SerializerTest.php
@@ -1,6 +1,10 @@
 <?php
-namespace Mongolid;
+namespace Mongolid\Serializer;
 
+use MongoDB\BSON\UTCDateTime as MongoUTCDateTime;
+use MongoDB\BSON\ObjectID as MongoObjectID;
+use Mongolid\Serializer\Type\ObjectID;
+use Mongolid\Serializer\Type\UTCDateTime;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -8,4 +12,171 @@ use PHPUnit_Framework_TestCase as TestCase;
  */
 class SerializerTest extends TestCase
 {
+    /**
+     * @var Serializer
+     */
+    protected $serializer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->serializer = new Serializer();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->serializer);
+    }
+
+    /**
+     * This test just check if Mongo driver still blocking us to serialize
+     * their BSON objects. If this test fails, maybe Serializer namespace should
+     * be removed =)
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage Serialization of 'MongoDB\BSON\ObjectID' is not allowed
+     */
+    public function testSerializeMongoObjectShouldTrhowException()
+    {
+        serialize(['id' => new MongoObjectID()]);
+    }
+
+    public function testSerializerShouldSerializeReplacingMongoDBObjects()
+    {
+        $mongoId   = new MongoObjectID();
+        $mongoDate = new MongoUTCDateTime(time()*1000);
+        $id        = new ObjectID($mongoId);
+        $date      = new UTCDateTime($mongoDate);
+
+        $attributes = [
+            '_id' => $mongoId,
+            'created_at' => $mongoDate,
+            'parents' => [$mongoId, $mongoId, $mongoId],
+            'comments' => [
+                [
+                    'author' => 'Jhon',
+                    'date' => $mongoDate,
+                ],
+                [
+                    'author' => 'Doe',
+                    'date' => $mongoDate,
+                    'versions' => [
+                        [
+                            '_id' => $mongoId,
+                            'date' => $mongoDate,
+                            'content' => 'Awsome',
+                        ],
+                        [
+                            '_id' => $mongoId,
+                            'date' => $mongoDate,
+                            'content' => 'Great',
+                        ],
+                    ]
+                ],
+            ]
+        ];
+
+        $expected = [
+            '_id' => $id,
+            'created_at' => $date,
+            'parents' => [$id, $id, $id],
+            'comments' => [
+                [
+                    'author' => 'Jhon',
+                    'date' => $date,
+                ],
+                [
+                    'author' => 'Doe',
+                    'date' => $date,
+                    'versions' => [
+                        [
+                            '_id' => $id,
+                            'date' => $date,
+                            'content' => 'Awsome',
+                        ],
+                        [
+                            '_id' => $id,
+                            'date' => $date,
+                            'content' => 'Great',
+                        ],
+                    ]
+                ],
+            ]
+        ];
+
+        $this->assertEquals(
+            $expected,
+            unserialize($this->serializer->serialize($attributes))
+        );
+    }
+
+    public function testUnserializeShouldConvertStringToMongoDBObjects()
+    {
+        $mongoId   = new MongoObjectID();
+        $mongoDate = new MongoUTCDateTime(time()*1000);
+        $id        = new ObjectID($mongoId);
+        $date      = new UTCDateTime($mongoDate);
+
+        $data = serialize([
+            '_id' => $id,
+            'created_at' => $date,
+            'parents' => [$id, $id, $id],
+            'comments' => [
+                [
+                    'author' => 'Jhon',
+                    'date' => $date,
+                ],
+                [
+                    'author' => 'Doe',
+                    'date' => $date,
+                    'versions' => [
+                        [
+                            '_id' => $id,
+                            'date' => $date,
+                            'content' => 'Awsome',
+                        ],
+                        [
+                            '_id' => $id,
+                            'date' => $date,
+                            'content' => 'Great',
+                        ],
+                    ]
+                ],
+            ]
+        ]);
+
+        $expected = [
+            '_id' => $mongoId,
+            'created_at' => $mongoDate,
+            'parents' => [$mongoId, $mongoId, $mongoId],
+            'comments' => [
+                [
+                    'author' => 'Jhon',
+                    'date' => $mongoDate,
+                ],
+                [
+                    'author' => 'Doe',
+                    'date' => $mongoDate,
+                    'versions' => [
+                        [
+                            '_id' => $mongoId,
+                            'date' => $mongoDate,
+                            'content' => 'Awsome',
+                        ],
+                        [
+                            '_id' => $mongoId,
+                            'date' => $mongoDate,
+                            'content' => 'Great',
+                        ],
+                    ]
+                ],
+            ]
+        ];
+
+        $this->assertEquals($expected, $this->serializer->unserialize($data));
+    }
 }

--- a/tests/Mongolid/Serializer/SerializerTest.php
+++ b/tests/Mongolid/Serializer/SerializerTest.php
@@ -1,0 +1,11 @@
+<?php
+namespace Mongolid;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Test case for Serializer class
+ */
+class SerializerTest extends TestCase
+{
+}

--- a/tests/Mongolid/Serializer/Type/ObjectIDTest.php
+++ b/tests/Mongolid/Serializer/Type/ObjectIDTest.php
@@ -25,6 +25,7 @@ class ObjectIDTest extends TestCase
      */
     public function setUp()
     {
+        parent::setUp();
         $this->mongoId = new MongoObjectID($this->stringId);
     }
 

--- a/tests/Mongolid/Serializer/Type/ObjectIDTest.php
+++ b/tests/Mongolid/Serializer/Type/ObjectIDTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace Mongolid\Serializer\Type;
+
+use MongoDB\BSON\ObjectID as MongoObjectID;
+use Mongolid\Serializer\SerializableTypeInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Test case for ObjectID class
+ */
+class ObjectIDTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $stringId = '000000000000000000001234';
+
+    /**
+     * @var MongoObjectID
+     */
+    protected $mongoId;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->mongoId = new MongoObjectID($this->stringId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->stringId);
+        unset($this->mongoId);
+    }
+
+    public function testObjectIDShouldBeSerializable()
+    {
+        $this->assertInstanceOf(
+            SerializableTypeInterface::class,
+            new ObjectID($this->mongoId)
+        );
+    }
+
+    public function testConstructorShouldCastMongoDBObjectIDToString()
+    {
+        $this->assertAttributeEquals(
+            $this->stringId,
+            'id',
+            new ObjectID($this->mongoId)
+        );
+    }
+
+    public function testSerializeShouldConvertObjectIDToString()
+    {
+        $objectId = unserialize(serialize(new ObjectID($this->mongoId)));
+
+        $this->assertAttributeEquals($this->stringId, 'id', $objectId);
+    }
+
+    public function testConvertShouldRetrieveMongoDBObjectID()
+    {
+        $objectId = new ObjectID($this->mongoId);
+        $this->assertEquals($this->mongoId, $objectId->convert());
+    }
+}

--- a/tests/Mongolid/Serializer/Type/ObjectIDTest.php
+++ b/tests/Mongolid/Serializer/Type/ObjectIDTest.php
@@ -39,7 +39,7 @@ class ObjectIDTest extends TestCase
         unset($this->mongoId);
     }
 
-    public function testObjectIDShouldBeSerializable()
+    public function testObjectIdShouldBeSerializable()
     {
         $this->assertInstanceOf(
             SerializableTypeInterface::class,
@@ -47,7 +47,7 @@ class ObjectIDTest extends TestCase
         );
     }
 
-    public function testConstructorShouldCastMongoDBObjectIDToString()
+    public function testConstructorShouldCastMongodbObjectIdToString()
     {
         $this->assertAttributeEquals(
             $this->stringId,
@@ -63,7 +63,7 @@ class ObjectIDTest extends TestCase
         $this->assertAttributeEquals($this->stringId, 'id', $objectId);
     }
 
-    public function testConvertShouldRetrieveMongoDBObjectID()
+    public function testConvertShouldRetrieveMongodbObjectId()
     {
         $objectId = new ObjectID($this->mongoId);
         $this->assertEquals($this->mongoId, $objectId->convert());

--- a/tests/Mongolid/Serializer/Type/ObjectIDTest.php
+++ b/tests/Mongolid/Serializer/Type/ObjectIDTest.php
@@ -55,7 +55,7 @@ class ObjectIDTest extends TestCase
         );
     }
 
-    public function testSerializeShouldConvertObjectIDToString()
+    public function testUnserializeShouldKeepStringId()
     {
         $objectId = unserialize(serialize(new ObjectID($this->mongoId)));
 

--- a/tests/Mongolid/Serializer/Type/UTCDatetimeTest.php
+++ b/tests/Mongolid/Serializer/Type/UTCDatetimeTest.php
@@ -41,7 +41,7 @@ class UTCDateTimeTest extends TestCase
         unset($this->mongoDate);
     }
 
-    public function testUTCDateTimeShouldBeSerializable()
+    public function testUtcDateTimeShouldBeSerializable()
     {
         $this->assertInstanceOf(
             SerializableTypeInterface::class,
@@ -49,7 +49,7 @@ class UTCDateTimeTest extends TestCase
         );
     }
 
-    public function testConstructorShouldCastMongoDBUTCDateTimeToString()
+    public function testConstructorShouldCastMongodbUtcDateTimeToString()
     {
         $this->assertAttributeEquals(
             $this->formatedDate,
@@ -65,7 +65,7 @@ class UTCDateTimeTest extends TestCase
         $this->assertAttributeEquals($this->formatedDate, 'date', $date);
     }
 
-    public function testConvertShouldRetrieveMongoDBUTCDateTime()
+    public function testConvertShouldRetrieveMongodbUtcDateTime()
     {
         $date = new UTCDateTime($this->mongoDate);
         $this->assertEquals($this->mongoDate, $date->convert());

--- a/tests/Mongolid/Serializer/Type/UTCDatetimeTest.php
+++ b/tests/Mongolid/Serializer/Type/UTCDatetimeTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Mongolid\Serializer\Type;
+
+use DateTime;
+use MongoDB\BSON\UTCDateTime as MongoUTCDateTime;
+use Mongolid\Serializer\SerializableTypeInterface;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * Test case for UTCDateTime class
+ */
+class UTCDateTimeTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $formatedDate = '1990-02-20 21:45:00';
+
+    /**
+     * @var MongoUTCDateTime
+     */
+    protected $mongoDate;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $now = DateTime::createFromFormat('Y-m-d H:i:s', $this->formatedDate);
+        $this->mongoDate = new MongoUTCDateTime($now->getTimestamp()*1000);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->formatedDate);
+        unset($this->mongoDate);
+    }
+
+    public function testUTCDateTimeShouldBeSerializable()
+    {
+        $this->assertInstanceOf(
+            SerializableTypeInterface::class,
+            new UTCDateTime($this->mongoDate)
+        );
+    }
+
+    public function testConstructorShouldCastMongoDBUTCDateTimeToString()
+    {
+        $this->assertAttributeEquals(
+            $this->formatedDate,
+            'date',
+            new UTCDateTime($this->mongoDate)
+        );
+    }
+
+    public function testUnserializeShouldKeepFormatedDate()
+    {
+        $date = unserialize(serialize(new UTCDateTime($this->mongoDate)));
+
+        $this->assertAttributeEquals($this->formatedDate, 'date', $date);
+    }
+
+    public function testConvertShouldRetrieveMongoDBUTCDateTime()
+    {
+        $date = new UTCDateTime($this->mongoDate);
+        $this->assertEquals($this->mongoDate, $date->convert());
+    }
+}

--- a/tests/Mongolid/Serializer/Type/UTCDatetimeTest.php
+++ b/tests/Mongolid/Serializer/Type/UTCDatetimeTest.php
@@ -26,6 +26,7 @@ class UTCDateTimeTest extends TestCase
      */
     public function setUp()
     {
+        parent::setUp();
         $now = DateTime::createFromFormat('Y-m-d H:i:s', $this->formatedDate);
         $this->mongoDate = new MongoUTCDateTime($now->getTimestamp()*1000);
     }


### PR DESCRIPTION
 This implementation is necessary due to a bug in MongoDB driver that doesn't allow to serialize some objects, i.e, ObjectID, UTCDateTime.

```php
<?php
class Entity extends ActiveRecord {
}
serialize(new Entity());
```

It throws an exception
`Serialization of 'MongoDB\BSON\ObjectID' is not allowed`

This bug is on track and being developed:
https://jira.mongodb.org/browse/PHPC-460

When the fix is deployed, we can remove this