### PR TITLE
Project fields in Mongo queries

### DIFF
--- a/src/Mongolid/DataMapper/DataMapper.php
+++ b/src/Mongolid/DataMapper/DataMapper.php
@@ -207,20 +207,27 @@ class DataMapper
      * Retrieve a database cursor that will return $this->schema->entityClass
      * objects that upon iteration
      *
-     * @param  mixed   $query     MongoDB query to retrieve documents.
-     * @param  boolean $cacheable Retrieves a CacheableCursor instead.
+     * @param  mixed   $query      MongoDB query to retrieve documents.
+     * @param  array   $projection Fields to project in Mongo query.
+     * @param  boolean $cacheable  Retrieves a CacheableCursor instead.
      *
      * @return \Mongolid\Cursor\Cursor
      */
-    public function where($query = [], bool $cacheable = false): Cursor
-    {
+    public function where(
+        $query = [],
+        array $projection = [],
+        bool $cacheable = false
+    ): Cursor {
         $cursorClass = $cacheable ? CacheableCursor::class : Cursor::class;
 
         $cursor = new $cursorClass(
             $this->schema,
             $this->getCollection(),
             'find',
-            [$this->prepareValueQuery($query)]
+            [
+                $this->prepareValueQuery($query),
+                ['projection' => $this->prepareProjection($projection)]
+            ]
         );
 
         return $cursor;
@@ -241,19 +248,24 @@ class DataMapper
      * Retrieve one $this->schema->entityClass objects that matches the given
      * query
      *
-     * @param  mixed   $query     MongoDB query to retrieve the document.
-     * @param  boolean $cacheable Retrieves the first through a CacheableCursor.
+     * @param  mixed   $query      MongoDB query to retrieve the document.
+     * @param  array   $projection Fields to project in Mongo query.
+     * @param  boolean $cacheable  Retrieves the first through a CacheableCursor.
      *
      * @return mixed First document matching query as an $this->schema->entityClass object
      */
-    public function first($query = [], bool $cacheable = false)
-    {
+    public function first(
+        $query = [],
+        array $projection = [],
+        bool $cacheable = false
+    ) {
         if ($cacheable) {
-            return $this->where($query, true)->first();
+            return $this->where($query, $projection, true)->first();
         }
 
         $document = $this->getCollection()->findOne(
-            $this->prepareValueQuery($query)
+            $this->prepareValueQuery($query),
+            ['projection' => $this->prepareProjection($projection)]
         );
 
         if (! $document) {

--- a/tests/Mongolid/DataMapper/DataMapperTest.php
+++ b/tests/Mongolid/DataMapper/DataMapperTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Mongolid\DataMapper;
 
 use Mockery as m;
@@ -427,6 +426,44 @@ class DataMapperTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function testShouldGetFirstProjectingFields()
+    {
+        // Arrange
+        $connPool = m::mock(Pool::class);
+        $mapper   = m::mock(DataMapper::class . '[prepareValueQuery,getCollection]', [$connPool]);
+        $schema   = m::mock(Schema::class);
+
+        $collection    = m::mock(Collection::class);
+        $query         = 123;
+        $preparedQuery = ['_id' => 123];
+
+        $schema->entityClass = 'stdClass';
+        $mapper->schema      = $schema;
+
+        $mapper->shouldAllowMockingProtectedMethods();
+
+        // Expect
+        $mapper->shouldReceive('prepareValueQuery')
+            ->once()
+            ->with($query)
+            ->andReturn($preparedQuery);
+
+        $mapper->shouldReceive('getCollection')
+            ->once()
+            ->andReturn($collection);
+
+        $collection->shouldReceive('findOne')
+            ->once()
+            ->with($preparedQuery)
+            ->andReturn(null);
+
+        // Act
+        $result = $mapper->first($query);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
     public function testShouldGetFirstTroughACacheableCursor()
     {
         // Arrange
@@ -546,6 +583,37 @@ class DataMapperTest extends TestCase
         $this->assertEquals($expectation, $result);
     }
 
+    /**
+     * @dataProvider getProjections
+     */
+    public function testPrepareProjectionShouldConvertArray($data, $expectation)
+    {
+        // Arrange
+        $connPool = m::mock(Pool::class);
+        $mapper   = new DataMapper($connPool);
+
+        // Act
+        $result = $this->callProtected($mapper, 'prepareProjection', [$data]);
+
+        // Assert
+        $this->assertEquals($expectation, $result);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid projection: 'invalid-key' => 'invalid-value'
+     */
+    public function testPrepareProjectionShouldThrownAnException()
+    {
+        // Arrange
+        $connPool = m::mock(Pool::class);
+        $mapper   = new DataMapper($connPool);
+        $data     = ['valid' => true, 'invalid-key' => 'invalid-value'];
+
+        // Act
+        $this->callProtected($mapper, 'prepareProjection', [$data]);
+    }
+
     protected function getEventService()
     {
         if (! ($this->eventService ?? false)) {
@@ -637,6 +705,31 @@ class DataMapperTest extends TestCase
                 'writeConcern'         => 0,
                 'shouldFireEventAfter' => false,
                 'expected'             => false,
+            ],
+        ];
+    }
+
+    /**
+     * Retrieves projections that should be replaced by mapper
+     */
+    public function getProjections()
+    {
+        return [
+            'Should return self array' => [
+                'projection' => ['some' => true, 'fields' => false],
+                'expected'   => ['some' => true, 'fields' => false],
+            ],
+            'Should convert number' => [
+                'projection' => ['some' => 1, 'fields' => -1],
+                'expected'   => ['some' => true, 'fields' => false],
+            ],
+            'Should add true in fields' => [
+                'projection' => ['some', 'fields'],
+                'expected'   => ['some' => true, 'fields' => true],
+            ],
+            'Should add boolean values according to key value' => [
+                'projection' => ['-some', 'fields'],
+                'expected'   => ['some' => false, 'fields' => true],
             ],
         ];
     }


### PR DESCRIPTION
Applied `projection` parameter to `where` and `first` methods in order to retrieve only the given fields in query result.

This parameter can be used in some different ways:

```php
$fields = ['_id' => false, 'name' => true]; 
// Keep the same
$fields = ['_id' => -1, 'name' => 1]; 
// ['_id' => false, 'name' => true];
$fields = ['_id', 'name']; 
// ['_id' => true, 'name' => true]; 
$fields = ['-_id', 'name']; 
// ['_id' => false, 'name' => true]; 
$fields = ['-comments']; 
// Retrieves all fields except '
```