### PR TITLE
Change event fired by DataMapper to match legacy mongolid events

### DIFF
--- a/src/Mongolid/DataMapper/DataMapper.php
+++ b/src/Mongolid/DataMapper/DataMapper.php
@@ -413,7 +413,7 @@ class DataMapper
      */
     protected function fireEvent(string $event, $entity, bool $halt = false)
     {
-        $event = "mongolid.{$event}." . get_class($entity);
+        $event = "mongolid.{$event}: " . get_class($entity);
 
         $this->eventService ? $this->eventService : $this->eventService = Ioc::make(EventTriggerService::class);
 

--- a/tests/Mongolid/DataMapper/DataMapperTest.php
+++ b/tests/Mongolid/DataMapper/DataMapperTest.php
@@ -686,7 +686,7 @@ class DataMapperTest extends TestCase
 
     protected function expectEventToBeFired($event, $entity, bool $halt, $return = true)
     {
-        $event = 'mongolid.' . $event . '.' . get_class($entity);
+        $event = 'mongolid.' . $event . ': ' . get_class($entity);
 
         $this->getEventService()->shouldReceive('fire')
             ->with($event, $entity, $halt)
@@ -697,7 +697,7 @@ class DataMapperTest extends TestCase
 
     protected function expectEventNotToBeFired($event, $entity)
     {
-        $event = 'mongolid.' . $event . '.' . get_class($entity);
+        $event = 'mongolid.' . $event . ': ' . get_class($entity);
 
         $this->getEventService()->shouldReceive('fire')
             ->with($event, $entity, m::any())


### PR DESCRIPTION
Mongolid used to fire events with the pattern `mongolid.some-event: Some\Class\Name`

This was changed on new mongolid version. Are we keeping this BC @Zizaco ?

