### PR TITLE
Include option to disable mongo cursor timeout

### DIFF
--- a/src/Mongolid/Cursor/Cursor.php
+++ b/src/Mongolid/Cursor/Cursor.php
@@ -156,6 +156,21 @@ class Cursor implements CursorInterface, Serializable
     }
 
     /**
+     * Disable idle timeout of 10 minutes from MongoDB cursor.
+     * This method should be called before the cursor was started.
+     *
+     * @param boolean $flag Toggle timeout on or off.
+     *
+     * @return Cursor Returns this cursor.
+     */
+    public function disableTimeout(bool $flag = true)
+    {
+        $this->params[1]['noCursorTimeout'] = $flag;
+
+        return $this;
+    }
+
+    /**
      * Counts the number of results for this cursor
      *
      * @return integer The number of documents returned by this cursor's query.
@@ -225,7 +240,7 @@ class Cursor implements CursorInterface, Serializable
 
     /**
      * Refresh the cursor in order to be able to perform a rewind and iterate
-     * trought it again. A new request to the database will be made in the next
+     * through it again. A new request to the database will be made in the next
      * iteration.
      *
      * @return void

--- a/tests/Mongolid/Cursor/CursorTest.php
+++ b/tests/Mongolid/Cursor/CursorTest.php
@@ -69,6 +69,20 @@ class CursorTest extends TestCase
         );
     }
 
+    public function testShouldSetNoCursorTimeoutToTrue()
+    {
+        // Arrange
+        $cursor = $this->getCursor();
+
+        // Assert
+        $cursor->disableTimeout();
+        $this->assertAttributeEquals(
+            [[], ['noCursorTimeout' => true]],
+            'params',
+            $cursor
+        );
+    }
+
     public function testShouldCountDocuments()
     {
         // Arrange


### PR DESCRIPTION
If a cursor exceed a 10 minutes of idle time, mongo kills it by default.

We need to avoid this is some cases, setting an option before start the cursor:

http://php.net/manual/en/mongodb-driver-query.construct.php

Usage:
```
// disable timeout
$cursor = App\MyModel::where()->disableTimeout();

foreach($cursor as $entity) { // iterate without timeout
    //
}
```
