### PR TITLE
Fix Bug with Original Attributes

### DIFF
--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -334,7 +334,7 @@ abstract class ActiveRecord implements AttributesAccessInterface
         ];
 
         if ($result = $this->getDataMapper()->$action($this, $options)) {
-            $this->storeOriginalAttributes();
+            $this->syncOriginalAttributes();
         }
 
         return $result;

--- a/src/Mongolid/DataMapper/EntityAssembler.php
+++ b/src/Mongolid/DataMapper/EntityAssembler.php
@@ -78,7 +78,7 @@ class EntityAssembler
     protected function prepareOriginalAttributes($entity)
     {
         if ($entity instanceof AttributesAccessInterface) {
-            $entity->storeOriginalAttributes();
+            $entity->syncOriginalAttributes();
         }
 
         return $entity;

--- a/src/Mongolid/Model/Attributes.php
+++ b/src/Mongolid/Model/Attributes.php
@@ -140,11 +140,9 @@ trait Attributes
      *
      * @return void
      */
-    public function storeOriginalAttributes()
+    public function syncOriginalAttributes()
     {
-        if (empty($this->original)) {
-            $this->original = $this->attributes;
-        }
+        $this->original = $this->attributes;
     }
 
     /**

--- a/src/Mongolid/Model/AttributesAccessInterface.php
+++ b/src/Mongolid/Model/AttributesAccessInterface.php
@@ -67,5 +67,5 @@ interface AttributesAccessInterface
      *
      * @return void
      */
-    public function storeOriginalAttributes();
+    public function syncOriginalAttributes();
 }

--- a/tests/Mongolid/ActiveRecordTest.php
+++ b/tests/Mongolid/ActiveRecordTest.php
@@ -64,7 +64,7 @@ class ActiveRecordTest extends TestCase
     public function testShouldSave()
     {
         // Arrage
-        $entity = m::mock(ActiveRecord::class.'[getDataMapper,getCollectionName,storeOriginalAttributes]');
+        $entity = m::mock(ActiveRecord::class.'[getDataMapper,getCollectionName,syncOriginalAttributes]');
         $dataMapper = m::mock();
 
         // Act
@@ -74,7 +74,7 @@ class ActiveRecordTest extends TestCase
         $entity->shouldReceive('getCollectionName')
             ->andReturn('mongolid');
 
-        $entity->shouldReceive('storeOriginalAttributes')
+        $entity->shouldReceive('syncOriginalAttributes')
             ->once();
 
         $dataMapper->shouldReceive('save')
@@ -89,7 +89,7 @@ class ActiveRecordTest extends TestCase
     public function testShouldInsert()
     {
         // Arrage
-        $entity = m::mock(ActiveRecord::class.'[getDataMapper,getCollectionName,storeOriginalAttributes]');
+        $entity = m::mock(ActiveRecord::class.'[getDataMapper,getCollectionName,syncOriginalAttributes]');
         $dataMapper = m::mock();
 
         // Act
@@ -99,7 +99,7 @@ class ActiveRecordTest extends TestCase
         $entity->shouldReceive('getCollectionName')
             ->andReturn('mongolid');
 
-        $entity->shouldReceive('storeOriginalAttributes')
+        $entity->shouldReceive('syncOriginalAttributes')
             ->once();
 
         $dataMapper->shouldReceive('insert')
@@ -114,7 +114,7 @@ class ActiveRecordTest extends TestCase
     public function testShouldUpdate()
     {
         // Arrage
-        $entity = m::mock(ActiveRecord::class.'[getDataMapper,getCollectionName,storeOriginalAttributes]');
+        $entity = m::mock(ActiveRecord::class.'[getDataMapper,getCollectionName,syncOriginalAttributes]');
         $dataMapper = m::mock();
 
         // Act
@@ -124,7 +124,7 @@ class ActiveRecordTest extends TestCase
         $entity->shouldReceive('getCollectionName')
             ->andReturn('mongolid');
 
-        $entity->shouldReceive('storeOriginalAttributes')
+        $entity->shouldReceive('syncOriginalAttributes')
             ->once();
 
         $dataMapper->shouldReceive('update')

--- a/tests/Mongolid/Model/AttributesTest.php
+++ b/tests/Mongolid/Model/AttributesTest.php
@@ -242,30 +242,10 @@ class AttributesTest extends TestCase
         $model->age = 25;
 
         // Act
-        $model->storeOriginalAttributes();
+        $model->syncOriginalAttributes();
 
         // Assert
         $this->assertAttributeEquals($model->attributes, 'original', $model);
-
-        return $model;
-    }
-
-    /**
-     * @depends testShouldSetOriginalAttributes
-     */
-    public function testShouldKeepOriginalAttributesIfPropertiesAreChangedAndMethodCalledAgain($model)
-    {
-        // Arrange
-        $expect = $model->attributes;
-
-        $model->name = 'Rick';
-        $model->age = 18;
-
-        // Act
-        $model->storeOriginalAttributes();
-
-        // Assert
-        $this->assertAttributeEquals($expect, 'original', $model);
     }
 
     public function getFillableOptions()


### PR DESCRIPTION
Closes #78
When saving model on `saved` event, attributes would been re-hashed due
to the lack of updated original attributes.