### PR TITLE
Implement Countable on CursorInterface

### DIFF
--- a/src/Mongolid/Cursor/Cursor.php
+++ b/src/Mongolid/Cursor/Cursor.php
@@ -21,7 +21,7 @@ use Mongolid\Schema\Schema;
  * 'where'. Because the mongodb library's MongoDB\Cursor is much more
  * limited (in that regard) than the old driver MongoCursor.
  */
-class Cursor implements CursorInterface, Countable, Serializable
+class Cursor implements CursorInterface, Serializable
 {
     /**
      * Schema that describes the entity that will be retrieved when iterating through the cursor.

--- a/src/Mongolid/Cursor/CursorInterface.php
+++ b/src/Mongolid/Cursor/CursorInterface.php
@@ -3,11 +3,12 @@
 namespace Mongolid\Cursor;
 
 use Iterator;
+use Countable;
 
 /**
  * Common interface for all kinds of cursors.
  */
-interface CursorInterface extends Iterator
+interface CursorInterface extends Countable, Iterator
 {
     /**
      * Limits the number of results returned.
@@ -37,13 +38,6 @@ interface CursorInterface extends Iterator
      * @return CursorInterface returns this cursor
      */
     public function skip(int $amount);
-
-    /**
-     * Counts the number of results for this cursor.
-     *
-     * @return int the number of documents returned by this cursor's query
-     */
-    public function count();
 
     /**
      * Returns the first element of the cursor.

--- a/tests/Mongolid/Cursor/EmbeddedCursorTest.php
+++ b/tests/Mongolid/Cursor/EmbeddedCursorTest.php
@@ -90,6 +90,20 @@ class EmbeddedCursorTest extends TestCase
         $this->assertEquals(3, $cursor->count());
     }
 
+    public function testShouldCountDocumentsWithCountFunction()
+    {
+        // Arrange
+        $items = [
+            ['name' => 'A'],
+            ['name' => 'B'],
+            ['name' => 'C'],
+        ];
+        $cursor = $this->getCursor(stdClass::class, $items);
+
+        // Assert
+        $this->assertEquals(3, count($cursor));
+    }
+
     public function testShouldRewind()
     {
         // Arrange


### PR DESCRIPTION
Move Countable to CursorInterface to allow EmbbedCursor takes benefit of `count()`