### PR TITLE
Connect option is invalid

### DIFF
--- a/src/Mongolid/Connection/Connection.php
+++ b/src/Mongolid/Connection/Connection.php
@@ -36,7 +36,7 @@ class Connection
      */
     public function __construct(
         string $server = 'mongodb://localhost:27017',
-        array $options = ['connect' => true],
+        array $options = [],
         array $driverOptions = []
     ) {
         // In order to work with PHP arrays instead of with objects

--- a/src/Mongolid/DataMapper/DataMapper.php
+++ b/src/Mongolid/DataMapper/DataMapper.php
@@ -492,10 +492,12 @@ class DataMapper implements HasSchemaInterface
             if (is_string($key)) {
                 if (is_bool($value)) {
                     $projection[$key] = $value;
+
                     continue;
                 }
                 if (is_int($value)) {
                     $projection[$key] = ($value >= 1);
+
                     continue;
                 }
             }
@@ -510,6 +512,7 @@ class DataMapper implements HasSchemaInterface
                 }
 
                 $projection[$key] = $value;
+
                 continue;
             }
 

--- a/src/Mongolid/Model/Attributes.php
+++ b/src/Mongolid/Model/Attributes.php
@@ -91,6 +91,7 @@ trait Attributes
         foreach ($input as $key => $value) {
             if ($force) {
                 $this->setAttribute($key, $value);
+
                 continue;
             }
 

--- a/tests/Mongolid/Connection/ConnectionTest.php
+++ b/tests/Mongolid/Connection/ConnectionTest.php
@@ -9,17 +9,26 @@ use TestCase;
 
 class ConnectionTest extends TestCase
 {
-    public function tearDown()
-    {
-        m::close();
-        parent::tearDown();
-    }
-
     public function testShouldConstructANewConnection()
     {
         // Arrange
         $server = 'mongodb://my-server/my_db';
-        $options = ['connect' => true];
+        $options = ['some', 'uri', 'options'];
+        $driverOptions = ['some', 'driver', 'options'];
+
+        // Act
+        $connection = new Connection($server, $options, $driverOptions);
+
+        // Assert
+        $this->assertAttributeInstanceOf(Client::class, 'rawConnection', $connection);
+        $this->assertAttributeEquals('my_db', 'defaultDatabase', $connection);
+    }
+
+    public function testShouldDetermineDatabaseFromACluster()
+    {
+        // Arrange
+        $server = 'mongodb://my-server,other-server/my_db?replicaSet=someReplica';
+        $options = ['some', 'uri', 'options'];
         $driverOptions = ['some', 'driver', 'options'];
 
         // Act
@@ -34,7 +43,7 @@ class ConnectionTest extends TestCase
     {
         // Arrange
         $server = 'mongodb://my-server/my_db';
-        $options = ['connect' => true];
+        $options = ['some', 'uri', 'options'];
         $driverOptions = ['some', 'driver', 'options'];
         $expectedParameters = [
             'uri' => $server,
@@ -57,7 +66,7 @@ class ConnectionTest extends TestCase
     {
         // Arrange
         $server = 'mongodb://my-server/my_db';
-        $options = ['connect' => true];
+        $options = ['some', 'uri', 'options'];
         $driverOptions = ['some', 'driver', 'options'];
 
         // Act

--- a/tests/Mongolid/Connection/ConnectionTest.php
+++ b/tests/Mongolid/Connection/ConnectionTest.php
@@ -2,7 +2,6 @@
 
 namespace Mongolid\Connection;
 
-use Mockery as m;
 use MongoDB\Client;
 use MongoDB\Driver\Manager;
 use TestCase;

--- a/tests/Mongolid/Model/DocumentEmbedderTest.php
+++ b/tests/Mongolid/Model/DocumentEmbedderTest.php
@@ -33,6 +33,7 @@ class DocumentEmbedderTest extends TestCase
         foreach ($expectation as $index => $expectedDoc) {
             if ($expectedDoc instanceof ObjectID) {
                 $this->assertEquals($expectedDoc, $result[$index]);
+
                 continue;
             }
 


### PR DESCRIPTION
According to https://docs.mongodb.com/manual/reference/connection-string/ `'connect' => true` isn't a valid option for MongoDB\Client uri options.

Maybe it's came from legacy mongodb driver