### PR TITLE
Consider mutators on __isset of Attributes

### DIFF
--- a/src/Mongolid/Model/Attributes.php
+++ b/src/Mongolid/Model/Attributes.php
@@ -212,7 +212,7 @@ trait Attributes
      */
     public function __isset($key)
     {
-        return isset($this->attributes[$key]);
+        return !is_null($this->{$key});
     }
 
     /**

--- a/tests/Mongolid/Model/AttributesTest.php
+++ b/tests/Mongolid/Model/AttributesTest.php
@@ -81,6 +81,26 @@ class AttributesTest extends TestCase
         $this->assertFalse(isset($model->nonexistant));
     }
 
+    public function testShouldCheckIfMutatedAttributeIsSet()
+    {
+        // Arrange
+        $model = new class() {
+            use Attributes;
+
+            public function getNameAttribute()
+            {
+                return 'John';
+            }
+        };
+
+        /* Enable mutator methods */
+        $model->mutable = true;
+
+        // Assert
+        $this->assertTrue(isset($model->name));
+        $this->assertFalse(isset($model->nonexistant));
+    }
+
     public function testShouldUnsetAttributes()
     {
         // Arrange


### PR DESCRIPTION
If a model uses mutators for its properties, the magic method `Attributes::__isset` will check the existence of it on the `attributes` array, causing undesired effects, such as returning `false` for a value set on a mutator.

This PR makes the `Attributes::__isset` check for the response of `Attributes::__get` (which will check for mutators) to determine if an attribute is set.