### PR TITLE
Updated to PHPUnit 6 and Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "satooshi/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^6.4",
         "squizlabs/php_codesniffer": "^2.0",
         "sami/sami": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "illuminate/container": "^5.4"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9",
+        "mockery/mockery": "^1.0",
         "satooshi/php-coveralls": "^1.0",
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "^2.0",
         "sami/sami": "^4.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"

--- a/tests/Mongolid/Util/LocalDateTimeTest.php
+++ b/tests/Mongolid/Util/LocalDateTimeTest.php
@@ -5,7 +5,7 @@ namespace Mongolid\Util;
 use DateTime;
 use DateTimeZone;
 use MongoDB\BSON\UTCDateTime;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class LocalDateTimeTest extends TestCase
 {


### PR DESCRIPTION
Updated to [PHPUnit 6](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0), and [Mockery 1](https://github.com/mockery/mockery/releases/tag/1.0).

Also added directive [`beStrictAboutTestsThatDoNotTestAnything="false"`](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0#backwards-compatibility-issues) for friendly output.