### PR TITLE
Allows Cursor to choose a member of the ReplicaSet

### DIFF
--- a/src/Mongolid/Cursor/Cursor.php
+++ b/src/Mongolid/Cursor/Cursor.php
@@ -148,6 +148,25 @@ class Cursor implements CursorInterface, Serializable
     }
 
     /**
+     *
+     * This describes how the Cursor route the future read operations to the members of a replica set.
+     *
+     * @link http://php.net/manual/pt_BR/class.mongodb-driver-readpreference.php
+     *
+     * @param int $mode Preference mode that the Cursor will use.
+     *
+     * @see ReadPreference::class To get a glance of the constants available
+     *
+     * @return $this
+     */
+    public function setReadPreference(int $mode)
+    {
+        $this->params[1]['readPreference'] = new ReadPreference($mode);
+
+        return $this;
+    }
+
+    /**
      * Counts the number of results for this cursor.
      *
      * @return int the number of documents returned by this cursor's query

--- a/src/Mongolid/Cursor/Cursor.php
+++ b/src/Mongolid/Cursor/Cursor.php
@@ -3,6 +3,7 @@
 namespace Mongolid\Cursor;
 
 use IteratorIterator;
+use MongoDB\Driver\ReadPreference;
 use Serializable;
 use Traversable;
 use MongoDB\Collection;
@@ -151,9 +152,9 @@ class Cursor implements CursorInterface, Serializable
      *
      * This describes how the Cursor route the future read operations to the members of a replica set.
      *
-     * @link http://php.net/manual/pt_BR/class.mongodb-driver-readpreference.php
+     * @see http://php.net/manual/pt_BR/class.mongodb-driver-readpreference.php
      *
-     * @param int $mode Preference mode that the Cursor will use.
+     * @param int $mode preference mode that the Cursor will use.
      *
      * @see ReadPreference::class To get a glance of the constants available
      *

--- a/src/Mongolid/Cursor/Cursor.php
+++ b/src/Mongolid/Cursor/Cursor.php
@@ -149,12 +149,11 @@ class Cursor implements CursorInterface, Serializable
     }
 
     /**
-     *
      * This describes how the Cursor route the future read operations to the members of a replica set.
      *
      * @see http://php.net/manual/pt_BR/class.mongodb-driver-readpreference.php
      *
-     * @param int $mode preference mode that the Cursor will use.
+     * @param int $mode preference mode that the Cursor will use
      *
      * @see ReadPreference::class To get a glance of the constants available
      *

--- a/tests/Mongolid/Cursor/CursorTest.php
+++ b/tests/Mongolid/Cursor/CursorTest.php
@@ -82,6 +82,19 @@ class CursorTest extends TestCase
         );
     }
 
+    public function testShouldSetReadPreferenceParameterAccordingly()
+    {
+        // Arrange
+        $cursor = $this->getCursor();
+        $mode = ReadPreference::RP_SECONDARY;
+        $cursor->setReadPreference($mode);
+        $readPreferenceParameter = $this->getProtected($cursor, 'params')[1]['readPreference'];
+
+        // Assert
+        $this->assertInstanceOf(ReadPreference::class, $readPreferenceParameter);
+        $this->assertSame($readPreferenceParameter->getMode(), $mode);
+    }
+
     public function testShouldCountDocuments()
     {
         // Arrange

--- a/tests/Mongolid/Cursor/CursorTest.php
+++ b/tests/Mongolid/Cursor/CursorTest.php
@@ -8,6 +8,7 @@ use IteratorIterator;
 use Mockery as m;
 use MongoDB\Collection;
 use MongoDB\Driver\Exception\LogicException;
+use MongoDB\Driver\ReadPreference;
 use Mongolid\ActiveRecord;
 use Mongolid\Connection\Connection;
 use Mongolid\Connection\Pool;


### PR DESCRIPTION
Setting the Read Preference is possible at multiple levels of the MongoDB driver. Creating a method at the Cursor when he instantiate the Collection allow us to choose the member (like preferring the Secondary) at a query-level based.

This permits more flexibility to distribute traffic on specific queries that do not rely so much at data that isn't stale.