### PR TITLE
Use atomic updates for update() method of data mapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ before_script:
 
 script:
   - vendor/bin/phpcs
-  - phpunit --testsuite unit -c phpunit.xml.dist
-  - phpunit --testsuite integration
+  - vendor/bin/phpunit -c phpunit.xml.dist
 
 after_script:
   - php vendor/bin/coveralls -v

--- a/src/DataMapper/SchemaMapper.php
+++ b/src/DataMapper/SchemaMapper.php
@@ -56,19 +56,12 @@ class SchemaMapper
             $data[$key] = $this->parseField($data[$key] ?? null, $fieldType);
         }
 
-        return $data;
-    }
-
-    /**
-     * If the schema is not dynamic, remove all non specified fields.
-     *
-     * @param array $data Reference of the fields. The passed array will be modified.
-     */
-    protected function clearDynamic(array &$data)
-    {
-        if (!$this->schema->dynamic) {
-            $data = array_intersect_key($data, $this->schema->fields);
-        }
+        return array_filter(
+            $data,
+            function ($value) {
+                return null !== $value;
+            }
+        );
     }
 
     /**
@@ -87,7 +80,7 @@ class SchemaMapper
         }
 
         // Returns null or an empty array
-        if (null === $value || is_array($value) && empty($value)) {
+        if (null === $value || [] === $value) {
             return $value;
         }
 
@@ -102,6 +95,18 @@ class SchemaMapper
         }
 
         return $value;
+    }
+
+    /**
+     * If the schema is not dynamic, remove all non specified fields.
+     *
+     * @param array $data Reference of the fields. The passed array will be modified.
+     */
+    protected function clearDynamic(array &$data)
+    {
+        if (!$this->schema->dynamic) {
+            $data = array_intersect_key($data, $this->schema->fields);
+        }
     }
 
     /**

--- a/src/Model/Attributes.php
+++ b/src/Model/Attributes.php
@@ -1,6 +1,8 @@
 <?php
 namespace Mongolid\Model;
 
+use Exception;
+
 /**
  * This trait adds attribute getter, setters and also a useful
  * `fill` method that can be used with $fillable and $guarded
@@ -71,10 +73,8 @@ trait Attributes
 
     /**
      * Get all attributes from the model.
-     *
-     * @return mixed
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -124,13 +124,28 @@ trait Attributes
     /**
      * Stores original attributes from actual data from attributes
      * to be used in future comparisons about changes.
+     * It tries to clone the attributes (using serialize/unserialize)
+     * so modifications to objects will be correctly identified
+     * as changes.
      *
      * Ideally should be called once right after retrieving data from
      * the database.
      */
     public function syncOriginalAttributes()
     {
-        $this->original = $this->attributes;
+        try {
+            $this->original = unserialize(serialize($this->attributes));
+        } catch (Exception $e) {
+            $this->original = $this->attributes;
+        }
+    }
+
+    /**
+     * Retrieve original attributes.
+     */
+    public function getOriginalAttributes(): array
+    {
+        return $this->original;
     }
 
     /**

--- a/src/Model/AttributesAccessInterface.php
+++ b/src/Model/AttributesAccessInterface.php
@@ -22,10 +22,8 @@ interface AttributesAccessInterface
 
     /**
      * Get all attributes from the model.
-     *
-     * @return mixed
      */
-    public function getAttributes();
+    public function getAttributes(): array;
 
     /**
      * Set the model attributes using an array.
@@ -36,7 +34,7 @@ interface AttributesAccessInterface
     public function fill(array $input, bool $force = false);
 
     /**
-     * Set a given attribute on the model.
+     * Unset a given attribute on the model.
      *
      * @param string $key name of the attribute to be unset
      */
@@ -58,4 +56,9 @@ interface AttributesAccessInterface
      * the database.
      */
     public function syncOriginalAttributes();
+
+    /**
+     * Retrieve original attributes.
+     */
+    public function getOriginalAttributes(): array;
 }

--- a/tests/Integration/PersistedDataTest.php
+++ b/tests/Integration/PersistedDataTest.php
@@ -31,7 +31,11 @@ class PersistedDataTest extends IntegrationTestCase
                 'email' => 'never',
             ],
             'friends' => [],
-            'address' => null,
+            'skills' => [
+                'PHP' => ['percentage' => '100%', 'version' => '7.0'],
+                'JavaScript' => ['percentage' => '80%', 'version' => 'ES6'],
+                'CSS' => ['percentage' => '45%', 'version' => 'CSS3'],
+            ],
         ];
 
         // Actions
@@ -56,14 +60,21 @@ class PersistedDataTest extends IntegrationTestCase
         $user->preferences = [];
         $user->friends = ['Mary'];
         $user->address = '123 Blue Street';
+        $user->skills->HTML = ['percentage' => '89%', 'version' => 'HTML5'];
+        $user->skills->PHP['version'] = '7.1';
 
         $expected = [
             '_id' => (string) $user->_id,
             'name' => 'Jane Doe',
-            'height' => null,
             'preferences' => [],
             'friends' => ['Mary'],
             'address' => '123 Blue Street',
+            'skills' => [
+                'PHP' => ['percentage' => '100%', 'version' => '7.1'],
+                'JavaScript' => ['percentage' => '80%', 'version' => 'ES6'],
+                'CSS' => ['percentage' => '45%', 'version' => 'CSS3'],
+                'HTML' => ['percentage' => '89%', 'version' => 'HTML5'],
+            ],
             'email' => 'jane@doe.com',
         ];
 
@@ -80,23 +91,29 @@ class PersistedDataTest extends IntegrationTestCase
     public function testUpdateData()
     {
         // Set
-        $user  = $this->getUser(true);
+        $user = $this->getUser(true);
 
         $user->name = 'Jane Doe';
-        $user->age = null; // TODO unset($user->age); not working right now - bug!
+        unset($user->age);
         $user->height = null;
         $user->email = 'jane@doe.com';
         $user->preferences = [];
         $user->friends = ['Mary'];
         $user->address = '123 Blue Street';
+        $user->skills->HTML = ['percentage' => '89%', 'version' => 'HTML5'];
+        $user->skills->PHP['version'] = '7.1';
 
         $expected = [
             '_id' => (string) $user->_id,
             'name' => 'Jane Doe',
-            'age' => null,
-            'height' => null,
             'preferences' => [],
             'friends' => ['Mary'],
+            'skills' => [
+                'PHP' => ['percentage' => '100%', 'version' => '7.1'],
+                'JavaScript' => ['percentage' => '80%', 'version' => 'ES6'],
+                'CSS' => ['percentage' => '45%', 'version' => 'CSS3'],
+                'HTML' => ['percentage' => '89%', 'version' => 'HTML5'],
+            ],
             'address' => '123 Blue Street',
             'email' => 'jane@doe.com',
         ];
@@ -123,6 +140,11 @@ class PersistedDataTest extends IntegrationTestCase
         ];
         $user->friends = [];
         $user->address = null;
+        $user->skills = (object) [
+            'PHP' => ['percentage' => '100%', 'version' => '7.0'],
+            'JavaScript' => ['percentage' => '80%', 'version' => 'ES6'],
+            'CSS' => ['percentage' => '45%', 'version' => 'CSS3'],
+        ];
 
         if ($save) {
             $this->assertTrue($user->save(), 'Failed to save user!');

--- a/tests/Integration/PersistedDataTest.php
+++ b/tests/Integration/PersistedDataTest.php
@@ -36,6 +36,7 @@ class PersistedDataTest extends IntegrationTestCase
                 'JavaScript' => ['percentage' => '80%', 'version' => 'ES6'],
                 'CSS' => ['percentage' => '45%', 'version' => 'CSS3'],
             ],
+            'photos' => ['profile' => '/user-photo', 'icon' => '/user-icon'],
         ];
 
         // Actions
@@ -75,6 +76,7 @@ class PersistedDataTest extends IntegrationTestCase
                 'CSS' => ['percentage' => '45%', 'version' => 'CSS3'],
                 'HTML' => ['percentage' => '89%', 'version' => 'HTML5'],
             ],
+            'photos' => ['profile' => '/user-photo', 'icon' => '/user-icon'],
             'email' => 'jane@doe.com',
         ];
 
@@ -114,6 +116,7 @@ class PersistedDataTest extends IntegrationTestCase
                 'CSS' => ['percentage' => '45%', 'version' => 'CSS3'],
                 'HTML' => ['percentage' => '89%', 'version' => 'HTML5'],
             ],
+            'photos' => ['profile' => '/user-photo', 'icon' => '/user-icon'],
             'address' => '123 Blue Street',
             'email' => 'jane@doe.com',
         ];
@@ -145,6 +148,13 @@ class PersistedDataTest extends IntegrationTestCase
             'JavaScript' => ['percentage' => '80%', 'version' => 'ES6'],
             'CSS' => ['percentage' => '45%', 'version' => 'CSS3'],
         ];
+
+        // dinamically set array
+        $user->photos['profile'] = '/user-photo';
+        $user->photos['icon'] = '/user-icon';
+
+        // access unknown field and don't find it saved later.
+        $user->unknown;
 
         if ($save) {
             $this->assertTrue($user->save(), 'Failed to save user!');

--- a/tests/Unit/DataMapper/EntityAssemblerTest.php
+++ b/tests/Unit/DataMapper/EntityAssemblerTest.php
@@ -265,7 +265,7 @@ class StubStudent extends stdClass implements AttributesAccessInterface
             $this->$key = $value;
         }
 
-        $this->original = $this->attributes;
+        $this->syncOriginalAttributes();
     }
 }
 


### PR DESCRIPTION
- [X] Better `update` method (fixes #122)
- [X] Stop saving fields with value `null`
- [x] Allow modification of array values directly

----

Previously, our update method would send all fields to `updateOne` on mongodb, *even if it was not modified*. It was both slow and could have undesired effects, like two update operations on different php processes could lead to a racing condition where some data would go missing.

Now it accounts for changed fields only, and also uses `$unset` to remove fields (fixes #122).

Other change brought by this PR is not saving fields with `null` values anymore (only `null`, empty strings/false/empty arrays/zeros are still being saved). Take a look on [this](https://stackoverflow.com/questions/12403240/storing-null-vs-not-storing-the-key-at-all-in-mongodb) and [this](https://docs.mongodb.com/manual/tutorial/query-for-null-fields/) if you have questions regarding this practice.

And perhaps the most developer friendly change:

```php
// previously
$array = $model->array;
$array['key'] = 'value';
$model->array = $array;

// now
$model->array['key'] = 'value';
```

(notice, it might lead to a very specific edge case with `$mutable = true`  and setting an key dinamically, but it worth the risk IMO)