### PR TITLE
Adicionando Suporte a múltiplos bancos de dados

### DIFF
--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -55,6 +55,13 @@ abstract class ActiveRecord implements AttributesAccessInterface, HasSchemaInter
     ];
 
     /**
+     * The database that the current model uses.
+     *
+     * @var string
+     */
+    protected $database = '';
+
+    /**
      * The $dynamic property tells if the object will accept additional fields
      * that are not specified in the $fields property. This is useful if you
      * does not have a strict document format or if you want to take full
@@ -249,6 +256,10 @@ abstract class ActiveRecord implements AttributesAccessInterface, HasSchemaInter
     {
         $dataMapper = Ioc::make(DataMapper::class);
         $dataMapper->setSchema($this->getSchema());
+        
+        if($this->database){
+            $dataMapper->database = $this->database;
+        }
 
         return $dataMapper;
     }

--- a/src/Mongolid/ActiveRecord.php
+++ b/src/Mongolid/ActiveRecord.php
@@ -256,7 +256,8 @@ abstract class ActiveRecord implements AttributesAccessInterface, HasSchemaInter
     {
         $dataMapper = Ioc::make(DataMapper::class);
         $dataMapper->setSchema($this->getSchema());
-        
+
+        // If needs a different DB
         if($this->database){
             $dataMapper->database = $this->database;
         }

--- a/src/Mongolid/DataMapper/DataMapper.php
+++ b/src/Mongolid/DataMapper/DataMapper.php
@@ -39,6 +39,13 @@ class DataMapper implements HasSchemaInterface
     protected $schema;
 
     /**
+     * The database to be interacted with.
+     *
+     * @var string
+     */
+    public $database = '';
+
+    /**
      * Connections that are going to be used to interact with the database.
      *
      * @var Pool
@@ -385,7 +392,7 @@ class DataMapper implements HasSchemaInterface
     protected function getCollection(): Collection
     {
         $conn = $this->connPool->getConnection();
-        $database = $conn->defaultDatabase;
+        $database = $this->database ?: $conn->defaultDatabase;
         $collection = $this->schema->collection;
 
         return $conn->getRawConnection()->$database->$collection;

--- a/tests/Mongolid/DataMapper/DataMapperTest.php
+++ b/tests/Mongolid/DataMapper/DataMapperTest.php
@@ -1216,4 +1216,32 @@ class DataMapperTest extends TestCase
             ],
         ];
     }
+
+    public function testShouldGetRawCollectionWithCustomDatabase()
+    {
+        // Arrange
+        $connPool = m::mock(Pool::class);
+        $mapper = new DataMapper($connPool);
+        $connection = m::mock(Connection::class);
+        $collection = m::mock(Collection::class);
+
+        $mapper->schema = (object) ['collection' => 'foobar'];
+        $mapper->database = 'test_database';
+        $connection->defaultDatabase = 'grimory';
+        $connection->test_database = (object) ['foobar' => $collection];
+
+        // Expect
+        $connPool->shouldReceive('getConnection')
+            ->once()
+            ->andReturn($connection);
+
+        $connection->shouldReceive('getRawConnection')
+            ->andReturn($connection);
+
+        // Act
+        $result = $this->callProtected($mapper, 'getCollection');
+
+        // Assert
+        $this->assertEquals($collection, $result);
+    }
 }


### PR DESCRIPTION
Baseando-me em: https://github.com/leroy-merlin-br/mongolid/pull/60
Implementei e testei, com essas modificações é possível definir diferentes bancos de dados para as collections, na mesma conexão.

Exemplo:
```php
<?php 
class UserLogAlbum extends \Mongolid\ActiveRecord {
    protected $collection = 'album';
    protected $database = 'userLog';
}
```