### PR TITLE
feat: change type return Relations.embledOne

### DIFF
--- a/src/Mongolid/Model/Relations.php
+++ b/src/Mongolid/Model/Relations.php
@@ -3,6 +3,7 @@
 namespace Mongolid\Model;
 
 use MongoDB\BSON\ObjectId;
+use Mongolid\ActiveRecord;
 use Mongolid\Container\Ioc;
 use Mongolid\Cursor\CursorFactory;
 use Mongolid\Cursor\EmbeddedCursor;
@@ -83,7 +84,7 @@ trait Relations
      * @param string $entity class of the entity or of the schema of the entity
      * @param string $field  field where the embedded document is stored
      *
-     * @return Model|null
+     * @return ActiveRecord|Schema|null
      */
     protected function embedsOne(string $entity, string $field)
     {


### PR DESCRIPTION
The `Mongolid/Model/Relations.embledOne` method now returns a `Model/Model`, but the correct would be to return `Mongolid\ActiveRecord` or `Mongolid\Schema\Schema`, this can give error in code analyzers.