### PR TITLE
Feat(MongoDB): Upgrade Driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.coverage
 /build
 /site
+.idea
+coverage

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "mongodb/mongodb": "^1.3",
+        "mongodb/mongodb": "1.8.0",
         "illuminate/container": "^5.8 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87ffe65ad677881ea00aad56d10cb946",
+    "content-hash": "bd6af4611956e2bfe8cacd986ce36967",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -266,12 +266,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "MongoDB\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "MongoDB\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - .:/var/www/html
 
   db:
-    image: mongo:4.0
-    command: mongod --smallfiles
+    image: mongo:4.2
+    command: mongod
     volumes:
       - db:/data/db
       - .:/var/www/html

--- a/src/Mongolid/Util/SequenceService.php
+++ b/src/Mongolid/Util/SequenceService.php
@@ -51,11 +51,16 @@ class SequenceService
             ['upsert' => true]
         );
 
-        if ($sequenceValue) {
-            $_id = $sequenceValue->seq + 1;
+        if (!$sequenceValue) {
+            return 1;
         }
 
-        return $_id ?? 1;
+        // On MongoDB 4.0 or below, this value will be an
+        // object. From 4.1 it is returned as an array.
+        // so we cast it to object to make sure.
+        $sequenceValue = (object) $sequenceValue;
+
+        return $sequenceValue->seq + 1;
     }
 
     /**

--- a/tests/Mongolid/Util/SequenceServiceTest.php
+++ b/tests/Mongolid/Util/SequenceServiceTest.php
@@ -38,9 +38,7 @@ class SequenceServiceTest extends TestCase
                 ['_id' => $sequenceName],
                 ['$inc' => ['seq' => 1]],
                 ['upsert' => true]
-            )->andReturn(
-                $currentValue ? (object) ['seq' => $currentValue] : null
-            );
+            )->andReturn($currentValue);
 
         // Assertion
         $this->assertEquals(
@@ -80,19 +78,22 @@ class SequenceServiceTest extends TestCase
         return [
             'New sequence in collection "products"' => [
                 'sequenceName' => 'products',
-                'currentValue' => 0,
+                'currentValue' => null,
                 'expectation' => 1,
             ],
-            // -----------------------
             'Existing sequence in collection "unicorns"' => [
                 'sequenceName' => 'unicorns',
-                'currentValue' => 7,
+                'currentValue' => (object) ['seq' => 7],
                 'expectation' => 8,
             ],
-            // -----------------------
-            'Existing sequence in collection "unicorns"' => [
+            'Existing one more sequence in collection "unicorns"' => [
                 'sequenceName' => 'unicorns',
-                'currentValue' => 3,
+                'currentValue' => (object) ['seq' => 3],
+                'expectation' => 4,
+            ],
+            'Returned as an array instead of object' => [
+                'sequenceName' => 'unicorns',
+                'currentValue' => ['seq' => 3],
                 'expectation' => 4,
             ],
         ];


### PR DESCRIPTION
Updates the mongodb driver to 1.8.0 to support mongo 4.2 version.
Also, updates the mongodb docker to 4.2

On this new version, the findOneAndUpdate from RawCollection returns the result as array instead of object. For this reason we are casting the result to make sure that we are always working with object.