### PR TITLE
fix: setup connection on connection manager

### DIFF
--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -46,12 +46,12 @@ class Manager
      * pure PHP. After adding a connection into the Manager you are ready to
      * persist and query your models.
      *
-     * @param IlluminateContainer $connection connection instance to be used in database interactions
+     * @param Connection $connection connection instance to be used in database interactions
      */
-    public function setConnection(IlluminateContainer $connection): bool
+    public function setConnection(Connection $connection): bool
     {
         $this->init();
-        $this->container->instance(IlluminateContainer::class, $this->connection);
+        $this->container->instance(Connection::class, $this->connection);
 
         $this->connection = $connection;
 

--- a/tests/Unit/Connection/ManagerTest.php
+++ b/tests/Unit/Connection/ManagerTest.php
@@ -14,7 +14,7 @@ final class ManagerTest extends TestCase
     {
         // Set
         $manager = new Manager();
-        $connection = m::mock(IlluminateContainer::class);
+        $connection = m::mock(Connection::class);
         $client = m::mock(Client::class);
 
         // Expectations


### PR DESCRIPTION
I'm studying mongolid following the documentation.

Right at the beginning, in the installation step, I believe I found a bug when configuring the Connection in Connection\Manager.

Seems to be a very old bug, probably hasn't been reported yet by anyone using the lib outside of Laravel.