### PR TITLE
fix(manager): set connection property before container instance

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -78,7 +78,7 @@ $post = Post::first(new MongoDB\BSON\ObjectID('4af9f23d8ead0e1d32000000'));
 #### Retrieving a document by attribute
 
 ```php
-$user = Post::first(['title' => 'How Mongolid saved the day']);
+$post = Post::first(['title' => 'How Mongolid saved the day']);
 ```
 
 #### Retrieving many documents by attribute

--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -51,9 +51,9 @@ class Manager
     public function setConnection(Connection $connection): bool
     {
         $this->init();
-        $this->container->instance(Connection::class, $this->connection);
 
         $this->connection = $connection;
+        $this->container->instance(Connection::class, $this->connection);
 
         return true;
     }


### PR DESCRIPTION
This fix the order of set connection property on Connection/Manager.

The other way connection always will use the default string.