### PR TITLE
Feat: Eager load using foreign keys

### DIFF
--- a/src/Model/HasLegacyRelationsTrait.php
+++ b/src/Model/HasLegacyRelationsTrait.php
@@ -34,7 +34,7 @@ trait HasLegacyRelationsTrait
      * @return mixed
      * @throws BindingResolutionException
      */
-    protected function referencesOne(string $entity, string $field, bool $cacheable = true)
+    protected function referencesOne(string $entity, string $field, bool $cacheable = true, string $foreignKey = '_id')
     {
         $referencedId = $this->$field;
 
@@ -52,10 +52,10 @@ trait HasLegacyRelationsTrait
             $dataMapper = Container::make(DataMapper::class);
             $dataMapper->setSchema($entityInstance);
 
-            return $dataMapper->first(['_id' => $referencedId], [], $cacheable);
+            return $dataMapper->first([$foreignKey => $referencedId], [], $cacheable);
         }
 
-        return $entityInstance::first(['_id' => $referencedId], [], $cacheable);
+        return $entityInstance::first([$foreignKey => $referencedId], [], $cacheable);
     }
 
     /**

--- a/src/Query/EagerLoader/Cache.php
+++ b/src/Query/EagerLoader/Cache.php
@@ -24,6 +24,11 @@ class Cache
         $model = Container::make($eagerLoadedModel['model']);
         $ids = array_values($eagerLoadedModel['ids'] ?? []);
 
+        // By default, the foreign key will always be the _id, but
+        // you can override this behavior by setting it on your
+        // model on the eager load settings.
+        $foreignKey = $eagerLoadedModel['foreignKey'] ?? '_id';
+
         // In case there is no IDs, means that either we don't
         // have any related models or models was not configured
         // correctly, in both case, we should not cache it.
@@ -31,7 +36,7 @@ class Cache
             return;
         }
 
-        $query = ['_id' => ['$in' => $ids]];
+        $query = [$foreignKey => ['$in' => $ids]];
         $count = 0;
 
         foreach ($model->where($query) as $relatedModel) {

--- a/src/Query/EagerLoader/Extractor.php
+++ b/src/Query/EagerLoader/Extractor.php
@@ -57,7 +57,7 @@ class Extractor
 
     private function addIdFor(string $eagerLoadKey, $id): void
     {
-        $this->relatedModels[$eagerLoadKey]['ids'][$id] = $id;
+        $this->relatedModels[$eagerLoadKey]['ids'][(string) $id] = $id;
     }
 
     /**
@@ -95,13 +95,6 @@ class Extractor
             // found on related model, we should warn that the user
             // is trying to eager load an invalid model.
             throw new EagerLoaderException('Referenced key was not found on child model.');
-        }
-
-        // We only want to object ids to string to give
-        // us some flexibility on array indexes.
-        // any other type of ids should remain the same.
-        if ($id instanceof ObjectId) {
-            $id = (string) $id;
         }
 
         $this->addIdFor($eagerLoadKey, $id);

--- a/tests/Stubs/Price.php
+++ b/tests/Stubs/Price.php
@@ -2,7 +2,6 @@
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;
-use Mongolid\Model\Relations\ReferencesOne;
 
 class Price extends AbstractModel
 {

--- a/tests/Stubs/Product.php
+++ b/tests/Stubs/Product.php
@@ -2,7 +2,6 @@
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\LegacyRecord;
-use Mongolid\Model\Relations\ReferencesOne;
 
 class Product extends LegacyRecord
 {

--- a/tests/Stubs/Product.php
+++ b/tests/Stubs/Product.php
@@ -15,6 +15,11 @@ class Product extends LegacyRecord
             'key' => '_id',
             'model' => Price::class
         ],
+        'stock' => [
+            'key' => '_id',
+            'foreignKey' => 'product_id',
+            'model' => Stock::class,
+        ],
         'shop' => [
             'key' => 'skus.shop_id',
             'model' => Shop::class,
@@ -24,6 +29,11 @@ class Product extends LegacyRecord
     public function price()
     {
         return $this->referencesOne(Price::class, '_id');
+    }
+
+    public function stock()
+    {
+        return $this->referencesOne(Stock::class, '_id', true, 'product_id');
     }
 
     public function skus()

--- a/tests/Stubs/Sku.php
+++ b/tests/Stubs/Sku.php
@@ -2,7 +2,6 @@
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\LegacyRecord;
-use Mongolid\Model\Relations\ReferencesOne;
 
 class Sku extends LegacyRecord
 {

--- a/tests/Stubs/Stock.php
+++ b/tests/Stubs/Stock.php
@@ -1,0 +1,12 @@
+<?php
+namespace Mongolid\Tests\Stubs;
+
+use Mongolid\Model\AbstractModel;
+
+class Stock extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    protected $collection = 'stocks';
+}


### PR DESCRIPTION
This will enable to eager load using a foreign keys other than `_id`.

The setup will be
```php
...

public $with = [
    'price' => [
        'key' => '_id',
        'foreignKey' => 'product_id',
        'model' => Price::class,
    ],
...
];