### PR TITLE
feat: add datetime casts

### DIFF
--- a/docs/docs/casting.md
+++ b/docs/docs/casting.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 6
+---
+
+# Casting attributes
+
+## Casting to DateTime
+
+
+With Mongolid, you can define attributes to be cast to `DateTime` or `DateTimeImmutable` using `$casts` property in your models. 
+
+```php
+class Person extends \Mongolid\Model\AbstractModel {
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'birthdate' => 'immutable_datetime',        
+    ];
+}
+```
+
+When you define an attribute to be cast as `DateTime` or `DateTimeImmutable`, Mongolid will load it from database will do its trick to return an `DateTime` instance(or `DateTimeImmutable`)  anytime you try to access it with property accessor operator (`->`).
+
+If you need to manipulate its original value on MongoDB, then you can access it through `getOriginalDocumentAttributes()` method
+
+To write a value on an attribute with `DateTime` cast, you can use both an `\MongoDB\BSON\UTCDateTime`, `\DateTime` or `\DateTimeImmutable` instance.
+Internally, Mongolid will manage to set the property as an UTCDateTime, because it is the datetime format accepted by MongoDB.
+
+Check out some usages and examples:
+
+```php
+
+$user = Person::first();
+$user->birthdate; // Returns birthdate as a DateTimeImmutable instance
+$user->expires_at; // Returns expires_at as DateTime instance
+
+$user->getOriginalDocumentAttributes()['birthdate']; // Returns birthdate as an \MongoDB\BSON\UTCDateTime instance
+
+// To set a new birthdate, you can pass both UTCDateTime or native's PHP DateTime
+$user->birthdate = new \MongoDB\BSON\UTCDateTime($anyDateTime);
+$user->birthdate = DateTime::createFromFormat('d/m/Y', '01/03/1970');
+
+
+```
+

--- a/docs/docs/casting.md
+++ b/docs/docs/casting.md
@@ -20,7 +20,7 @@ class Person extends \Mongolid\Model\AbstractModel {
 
 When you define an attribute to be cast as `DateTime` or `DateTimeImmutable`, Mongolid will load it from database will do its trick to return an `DateTime` instance(or `DateTimeImmutable`)  anytime you try to access it with property accessor operator (`->`).
 
-If you need to manipulate its original value on MongoDB, then you can access it through `getOriginalDocumentAttributes()` method
+If you need to manipulate its original value on MongoDB, then you can access it through `getDocumentAttributes()` method
 
 To write a value on an attribute with `DateTime` cast, you can use both an `\MongoDB\BSON\UTCDateTime`, `\DateTime` or `\DateTimeImmutable` instance.
 Internally, Mongolid will manage to set the property as an UTCDateTime, because it is the datetime format accepted by MongoDB.

--- a/src/Model/Casts/CastInterface.php
+++ b/src/Model/Casts/CastInterface.php
@@ -6,7 +6,7 @@ use MongoDB\BSON\UTCDateTime;
 
 interface CastInterface
 {
-    public static function get(mixed $value): mixed;
+    public function get(mixed $value): mixed;
 
-    public static function set(mixed $value): mixed;
+    public function set(mixed $value): mixed;
 }

--- a/src/Model/Casts/CastInterface.php
+++ b/src/Model/Casts/CastInterface.php
@@ -2,8 +2,6 @@
 
 namespace Mongolid\Model\Casts;
 
-use MongoDB\BSON\UTCDateTime;
-
 interface CastInterface
 {
     public function get(mixed $value): mixed;

--- a/src/Model/Casts/CastInterface.php
+++ b/src/Model/Casts/CastInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mongolid\Model\Casts;
+
+use MongoDB\BSON\UTCDateTime;
+
+interface CastInterface
+{
+    public static function get(mixed $value): mixed;
+
+    public static function set(mixed $value): mixed;
+}

--- a/src/Model/Casts/CastResolver.php
+++ b/src/Model/Casts/CastResolver.php
@@ -16,12 +16,8 @@ class CastResolver
         self::IMMUTABLE_DATE_TIME,
     ];
 
-    public static function resolve(?string $cast): ?CastInterface
+    public static function resolve(?string $cast): CastInterface
     {
-        if (is_null($cast)) {
-            return null;
-        }
-
         return match($cast) {
             self::DATE_TIME => new DateTimeCast(),
             self::IMMUTABLE_DATE_TIME => new ImmutableDateTimeCast(),

--- a/src/Model/Casts/CastResolver.php
+++ b/src/Model/Casts/CastResolver.php
@@ -16,7 +16,7 @@ class CastResolver
         self::IMMUTABLE_DATE_TIME,
     ];
 
-    public static function resolve(?string $cast): ?object
+    public static function resolve(?string $cast): ?CastInterface
     {
         if (is_null($cast)) {
             return null;

--- a/src/Model/Casts/CastResolver.php
+++ b/src/Model/Casts/CastResolver.php
@@ -18,7 +18,7 @@ class CastResolver
         self::IMMUTABLE_DATE_TIME,
     ];
 
-    public static function resolve(?string $castName): CastInterface
+    public static function resolve(string $castName): CastInterface
     {
         if ($cast = self::$cache[$castName] ?? null) {
             return $cast;

--- a/src/Model/Casts/CastResolver.php
+++ b/src/Model/Casts/CastResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Mongolid\Model\Casts;
+
+use Mongolid\Model\Casts\DateTime\DateTimeCast;
+use Mongolid\Model\Casts\DateTime\ImmutableDateTimeCast;
+use Mongolid\Model\Casts\Exceptions\InvalidCastException;
+
+class CastResolver
+{
+    private const DATE_TIME = 'datetime';
+    private const IMMUTABLE_DATE_TIME = 'immutable_datetime';
+
+    public static array $validCasts = [
+        self::DATE_TIME,
+        self::IMMUTABLE_DATE_TIME,
+    ];
+
+    public static function resolve(?string $cast): ?object
+    {
+        if (is_null($cast)) {
+            return null;
+        }
+
+        return match($cast) {
+            self::DATE_TIME => new DateTimeCast(),
+            self::IMMUTABLE_DATE_TIME => new ImmutableDateTimeCast(),
+            default => throw new InvalidCastException($cast),
+        };
+    }
+}

--- a/src/Model/Casts/CastResolver.php
+++ b/src/Model/Casts/CastResolver.php
@@ -11,17 +11,25 @@ class CastResolver
     private const DATE_TIME = 'datetime';
     private const IMMUTABLE_DATE_TIME = 'immutable_datetime';
 
+    private static array $cache = [];
+
     public static array $validCasts = [
         self::DATE_TIME,
         self::IMMUTABLE_DATE_TIME,
     ];
 
-    public static function resolve(?string $cast): CastInterface
+    public static function resolve(?string $castName): CastInterface
     {
-        return match($cast) {
+        if ($cast = self::$cache[$castName] ?? null) {
+            return $cast;
+        }
+
+        self::$cache[$castName] = match($castName) {
             self::DATE_TIME => new DateTimeCast(),
             self::IMMUTABLE_DATE_TIME => new ImmutableDateTimeCast(),
-            default => throw new InvalidCastException($cast),
+            default => throw new InvalidCastException($castName),
         };
+
+        return self::$cache[$castName];
     }
 }

--- a/src/Model/Casts/DateTime/BaseDateTimeCast.php
+++ b/src/Model/Casts/DateTime/BaseDateTimeCast.php
@@ -5,7 +5,6 @@ namespace Mongolid\Model\Casts\DateTime;
 use DateTimeInterface;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\BSON\UTCDateTimeInterface;
-use Mongolid\Model\Casts\CasterInterface;
 use Mongolid\Model\Casts\CastInterface;
 
 abstract class BaseDateTimeCast implements CastInterface

--- a/src/Model/Casts/DateTime/BaseDateTimeCast.php
+++ b/src/Model/Casts/DateTime/BaseDateTimeCast.php
@@ -14,13 +14,13 @@ abstract class BaseDateTimeCast implements CastInterface
      * @param UTCDateTime|null $value
      * @return DateTimeInterface|null
      */
-    abstract public static function get(mixed $value): mixed;
+    abstract public function get(mixed $value): mixed;
 
     /**
      * @param DateTimeInterface|UTCDateTimeInterface|null $value
      * @return UTCDateTime|null
      */
-    public static function set(mixed $value): mixed
+    public function set(mixed $value): mixed
     {
         if (is_null($value)) {
             return null;

--- a/src/Model/Casts/DateTime/BaseDateTimeCast.php
+++ b/src/Model/Casts/DateTime/BaseDateTimeCast.php
@@ -14,13 +14,13 @@ abstract class BaseDateTimeCast implements CastInterface
      * @param UTCDateTime|null $value
      * @return DateTimeInterface|null
      */
-    abstract public function get(mixed $value): mixed;
+    abstract public function get(mixed $value): DateTimeInterface|null;
 
     /**
      * @param DateTimeInterface|UTCDateTimeInterface|null $value
      * @return UTCDateTime|null
      */
-    public function set(mixed $value): mixed
+    public function set(mixed $value): UTCDateTime|null
     {
         if (is_null($value)) {
             return null;

--- a/src/Model/Casts/DateTime/BaseDateTimeCast.php
+++ b/src/Model/Casts/DateTime/BaseDateTimeCast.php
@@ -12,7 +12,7 @@ abstract class BaseDateTimeCast implements CastInterface
     /**
      * @param UTCDateTime|null $value
      */
-    abstract public function get(mixed $value): DateTimeInterface|null;
+    abstract public function get(mixed $value): ?DateTimeInterface;
 
     /**
      * @param DateTimeInterface|UTCDateTimeInterface|null $value

--- a/src/Model/Casts/DateTime/BaseDateTimeCast.php
+++ b/src/Model/Casts/DateTime/BaseDateTimeCast.php
@@ -12,13 +12,11 @@ abstract class BaseDateTimeCast implements CastInterface
 {
     /**
      * @param UTCDateTime|null $value
-     * @return DateTimeInterface|null
      */
     abstract public function get(mixed $value): DateTimeInterface|null;
 
     /**
      * @param DateTimeInterface|UTCDateTimeInterface|null $value
-     * @return UTCDateTime|null
      */
     public function set(mixed $value): UTCDateTime|null
     {

--- a/src/Model/Casts/DateTime/BaseDateTimeCast.php
+++ b/src/Model/Casts/DateTime/BaseDateTimeCast.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Mongolid\Model\Casts\DateTime;
+
+use DateTimeInterface;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\BSON\UTCDateTimeInterface;
+use Mongolid\Model\Casts\CasterInterface;
+use Mongolid\Model\Casts\CastInterface;
+
+abstract class BaseDateTimeCast implements CastInterface
+{
+    /**
+     * @param UTCDateTime|null $value
+     * @return DateTimeInterface|null
+     */
+    abstract public static function get(mixed $value): mixed;
+
+    /**
+     * @param DateTimeInterface|UTCDateTimeInterface|null $value
+     * @return UTCDateTime|null
+     */
+    public static function set(mixed $value): mixed
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if ($value instanceof UTCDateTimeInterface) {
+            return $value;
+        }
+
+        return new UTCDateTime($value);
+    }
+}

--- a/src/Model/Casts/DateTime/DateTimeCast.php
+++ b/src/Model/Casts/DateTime/DateTimeCast.php
@@ -12,7 +12,7 @@ class DateTimeCast extends BaseDateTimeCast
      * @param UTCDateTime|null $value
      * @return DateTime|null
      */
-    public function get(mixed $value): mixed
+    public function get(mixed $value): DateTime|null
     {
         if (is_null($value)) {
             return null;

--- a/src/Model/Casts/DateTime/DateTimeCast.php
+++ b/src/Model/Casts/DateTime/DateTimeCast.php
@@ -10,7 +10,6 @@ class DateTimeCast extends BaseDateTimeCast
 {
     /**
      * @param UTCDateTime|null $value
-     * @return DateTime|null
      */
     public function get(mixed $value): DateTime|null
     {

--- a/src/Model/Casts/DateTime/DateTimeCast.php
+++ b/src/Model/Casts/DateTime/DateTimeCast.php
@@ -11,7 +11,7 @@ class DateTimeCast extends BaseDateTimeCast
     /**
      * @param UTCDateTime|null $value
      */
-    public function get(mixed $value): DateTime|null
+    public function get(mixed $value): ?DateTime
     {
         if (is_null($value)) {
             return null;

--- a/src/Model/Casts/DateTime/DateTimeCast.php
+++ b/src/Model/Casts/DateTime/DateTimeCast.php
@@ -12,10 +12,9 @@ class DateTimeCast extends BaseDateTimeCast
      * @param UTCDateTime|null $value
      * @return DateTime|null
      */
-    public static function get(mixed $value): mixed
+    public function get(mixed $value): mixed
     {
         if (is_null($value)) {
-
             return null;
         }
 

--- a/src/Model/Casts/DateTime/DateTimeCast.php
+++ b/src/Model/Casts/DateTime/DateTimeCast.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Mongolid\Model\Casts\DateTime;
+
+use DateTime;
+use MongoDB\BSON\UTCDateTime;
+use Mongolid\Util\LocalDateTime;
+
+class DateTimeCast extends BaseDateTimeCast
+{
+    /**
+     * @param UTCDateTime|null $value
+     * @return DateTime|null
+     */
+    public static function get(mixed $value): mixed
+    {
+        if (is_null($value)) {
+
+            return null;
+        }
+
+        return LocalDateTime::get($value);
+    }
+}

--- a/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
+++ b/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Mongolid\Model\Casts\DateTime;
+
+use DateTimeImmutable;
+use MongoDB\BSON\UTCDateTime;
+use Mongolid\Util\LocalDateTime;
+
+class ImmutableDateTimeCast extends BaseDateTimeCast
+{
+    /**
+     * @param UTCDateTime|null $value
+     * @return DateTimeImmutable|null
+     */
+    public static function get(mixed $value): mixed
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        return DateTimeImmutable::createFromMutable(
+            LocalDateTime::get($value)
+        );
+    }
+}

--- a/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
+++ b/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
@@ -10,7 +10,6 @@ class ImmutableDateTimeCast extends BaseDateTimeCast
 {
     /**
      * @param UTCDateTime|null $value
-     * @return DateTimeImmutable|null
      */
     public function get(mixed $value): DateTimeImmutable|null
     {

--- a/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
+++ b/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
@@ -11,7 +11,7 @@ class ImmutableDateTimeCast extends BaseDateTimeCast
     /**
      * @param UTCDateTime|null $value
      */
-    public function get(mixed $value): DateTimeImmutable|null
+    public function get(mixed $value): ?DateTimeImmutable
     {
         if (is_null($value)) {
             return null;

--- a/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
+++ b/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
@@ -12,7 +12,7 @@ class ImmutableDateTimeCast extends BaseDateTimeCast
      * @param UTCDateTime|null $value
      * @return DateTimeImmutable|null
      */
-    public function get(mixed $value): mixed
+    public function get(mixed $value): DateTimeImmutable|null
     {
         if (is_null($value)) {
             return null;

--- a/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
+++ b/src/Model/Casts/DateTime/ImmutableDateTimeCast.php
@@ -12,7 +12,7 @@ class ImmutableDateTimeCast extends BaseDateTimeCast
      * @param UTCDateTime|null $value
      * @return DateTimeImmutable|null
      */
-    public static function get(mixed $value): mixed
+    public function get(mixed $value): mixed
     {
         if (is_null($value)) {
             return null;

--- a/src/Model/Casts/Exceptions/InvalidCastException.php
+++ b/src/Model/Casts/Exceptions/InvalidCastException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mongolid\Model\Casts\Exceptions;
+
+use InvalidArgumentException;
+use Mongolid\Model\Casts\CastResolver;
+
+class InvalidCastException extends InvalidArgumentException
+{
+    public function __construct(string $cast)
+    {
+        $available = implode(',', CastResolver::$validCasts);
+        $message = "Invalid cast attribute: $cast. Use a valid one like $available";
+
+        parent::__construct($message);
+    }
+}

--- a/src/Model/HasAttributesTrait.php
+++ b/src/Model/HasAttributesTrait.php
@@ -5,7 +5,6 @@ use Exception;
 use Illuminate\Support\Str;
 use Mongolid\Container\Container;
 use Mongolid\Model\Casts\CastResolver;
-use Mongolid\Model\Casts\DateTime\BaseDateTimeCast;
 use stdClass;
 
 /**

--- a/src/Model/HasAttributesTrait.php
+++ b/src/Model/HasAttributesTrait.php
@@ -69,11 +69,8 @@ trait HasAttributesTrait
 
     /**
      * Attributes that are cast to another types when fetched from database.
-     *
-     * @var array
      */
-    protected $casts = [];
-
+    protected array $casts = [];
 
     /**
      * {@inheritdoc}

--- a/src/Model/HasAttributesTrait.php
+++ b/src/Model/HasAttributesTrait.php
@@ -133,7 +133,8 @@ trait HasAttributesTrait
             return $this->mutableCache[$key];
         }
 
-        if ($caster = CastResolver::resolve($this->casts[$key] ?? null)) {
+        if ($casterName = $this->casts[$key] ?? null) {
+            $caster = CastResolver::resolve($casterName);
             $value = $caster->get($this->attributes[$key] ?? null);
 
             return $value;
@@ -187,7 +188,8 @@ trait HasAttributesTrait
             $value = $this->{$this->buildMutatorMethod($key, 'set')}($value);
         }
 
-        if ($caster = CastResolver::resolve($this->casts[$key] ?? null)) {
+        if ($casterName = $this->casts[$key] ?? null) {
+            $caster = CastResolver::resolve($casterName);
             $value = $caster->set($value);
         }
 

--- a/src/Model/HasLegacyAttributesTrait.php
+++ b/src/Model/HasLegacyAttributesTrait.php
@@ -2,9 +2,6 @@
 namespace Mongolid\Model;
 
 use Mongolid\Model\Casts\CastResolver;
-use Mongolid\Model\Casts\DateTime\BaseDateTimeCast;
-use Mongolid\Model\Casts\DateTime\DateTimeCast;
-use Mongolid\Model\Casts\DateTime\ImmutableDateTimeCast;
 
 /**
  * This trait adds attribute getter, setters and also a useful

--- a/src/Model/HasLegacyAttributesTrait.php
+++ b/src/Model/HasLegacyAttributesTrait.php
@@ -76,8 +76,10 @@ trait HasLegacyAttributesTrait
     {
         $inAttributes = array_key_exists($key, $this->attributes);
 
-        if ($caster = CastResolver::resolve($this->casts[$key] ?? null)) {
-            return  $caster->get($this->attributes[$key] ?? null);
+        if ($casterName = $this->casts[$key] ?? null) {
+            $caster = CastResolver::resolve($casterName);
+
+            return $caster->get($this->attributes[$key] ?? null);
         }
 
         if ($inAttributes) {
@@ -138,7 +140,8 @@ trait HasLegacyAttributesTrait
      */
     public function setAttribute(string $key, $value)
     {
-        if ($caster = CastResolver::resolve($this->casts[$key] ?? null)) {
+        if ($casterName = $this->casts[$key] ?? null) {
+            $caster = CastResolver::resolve($casterName);
             $value = $caster->set($value);
         }
 

--- a/src/Model/HasLegacyAttributesTrait.php
+++ b/src/Model/HasLegacyAttributesTrait.php
@@ -60,10 +60,8 @@ trait HasLegacyAttributesTrait
 
     /**
      * Attributes that are cast to another types when fetched from database.
-     *
-     * @var array
      */
-    protected $casts = [];
+    protected array $casts = [];
 
     /**
      * Get an attribute from the model.

--- a/src/Model/HasLegacyAttributesTrait.php
+++ b/src/Model/HasLegacyAttributesTrait.php
@@ -77,10 +77,7 @@ trait HasLegacyAttributesTrait
         $inAttributes = array_key_exists($key, $this->attributes);
 
         if ($caster = CastResolver::resolve($this->casts[$key] ?? null)) {
-            $value = $caster->get($this->attributes[$key] ?? null);
-            $this->attributes[$key] = $value;
-
-            return $this->attributes[$key];
+            return  $caster->get($this->attributes[$key] ?? null);
         }
 
         if ($inAttributes) {

--- a/tests/Integration/DateTimeCastTest.php
+++ b/tests/Integration/DateTimeCastTest.php
@@ -7,6 +7,7 @@ use MongoDB\BSON\UTCDateTime;
 use Mongolid\Tests\Integration\IntegrationTestCase;
 use Mongolid\Tests\Stubs\ExpirablePrice;
 use Mongolid\Tests\Stubs\Legacy\LegacyRecordUser;
+use Mongolid\Util\LocalDateTime;
 
 class DateTimeCastTest extends IntegrationTestCase
 {
@@ -28,7 +29,9 @@ class DateTimeCastTest extends IntegrationTestCase
         $this->assertSame('02/10/2025', $price->expires_at->format('d/m/Y'));
         $this->assertSame(
             '02/10/2025',
-            $price->getOriginalDocumentAttributes()['expires_at']->toDateTime()->format('d/m/Y')
+            LocalDateTime::get(
+                $price->getOriginalDocumentAttributes()['expires_at']->toDateTime()->format('d/m/Y')
+            )
         );
     }
 

--- a/tests/Integration/DateTimeCastTest.php
+++ b/tests/Integration/DateTimeCastTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Integration;
+
+use DateTime;
+use MongoDB\BSON\UTCDateTime;
+use Mongolid\Tests\Integration\IntegrationTestCase;
+use Mongolid\Tests\Stubs\ExpirablePrice;
+use Mongolid\Tests\Stubs\Legacy\LegacyRecordUser;
+
+class DateTimeCastTest extends IntegrationTestCase
+{
+    public function testShouldCreateAndSavePricesWithCastedAttributes(): void
+    {
+        // Set
+        $price = new ExpirablePrice();
+        $price->value = '100.0';
+        $price->expires_at = DateTime::createFromFormat('d/m/Y', '02/10/2025');
+
+        // Actions
+        $price->save();
+
+        // Assertions
+        $this->assertInstanceOf(DateTime::class, $price->expires_at);
+        $this->assertInstanceOf(UTCDateTime::class, $price->getOriginalDocumentAttributes()['expires_at']);
+
+        $price = ExpirablePrice::first($price->_id);
+        $this->assertSame('02/10/2025', $price->expires_at->format('d/m/Y'));
+        $this->assertSame(
+            '02/10/2025',
+            $price->getOriginalDocumentAttributes()['expires_at']->toDateTime()->format('d/m/Y')
+        );
+    }
+
+    public function testShouldUpdatePriceWithCastedAttributes(): void
+    {
+        // Set
+        $price = new ExpirablePrice();
+        $price->value = '100.0';
+        $price->expires_at = DateTime::createFromFormat('d/m/Y', '02/10/2025');
+
+        // Actions
+        $price->expires_at = DateTime::createFromFormat('d/m/Y', '02/10/2030');
+
+        // Assertions
+        $this->assertInstanceOf(DateTime::class, $price->expires_at);
+        $this->assertSame('02/10/2030', $price->expires_at->format('d/m/Y'));
+    }
+
+    public function testShouldSaveAndReadLegacyRecordWithCastedAttibutes(): void
+    {
+        // Set
+        $entity = new class extends LegacyRecordUser {
+            protected $casts = [
+                'expires_at' => 'datetime',
+            ];
+        };
+        $entity->expires_at = DateTime::createFromFormat('d/m/Y', '02/10/2025');
+
+        // Actions
+        $entity->save();
+
+        // Assertions
+        $this->assertInstanceOf(DateTime::class, $entity->expires_at);
+        $this->assertInstanceOf(UTCDateTime::class, $entity->getOriginalDocumentAttributes()['expires_at']);
+    }
+}

--- a/tests/Integration/DateTimeCastTest.php
+++ b/tests/Integration/DateTimeCastTest.php
@@ -53,7 +53,7 @@ class DateTimeCastTest extends IntegrationTestCase
     {
         // Set
         $entity = new class extends LegacyRecordUser {
-            protected $casts = [
+            protected array $casts = [
                 'expires_at' => 'datetime',
             ];
         };

--- a/tests/Integration/DateTimeCastTest.php
+++ b/tests/Integration/DateTimeCastTest.php
@@ -29,9 +29,8 @@ class DateTimeCastTest extends IntegrationTestCase
         $this->assertSame('02/10/2025', $price->expires_at->format('d/m/Y'));
         $this->assertSame(
             '02/10/2025',
-            LocalDateTime::get(
-                $price->getOriginalDocumentAttributes()['expires_at']->toDateTime()->format('d/m/Y')
-            )
+            LocalDateTime::get($price->getOriginalDocumentAttributes()['expires_at'])
+                ->format('d/m/Y')
         );
     }
 

--- a/tests/Stubs/ExpirablePrice.php
+++ b/tests/Stubs/ExpirablePrice.php
@@ -6,7 +6,7 @@ use DateTime;
 
 class ExpirablePrice extends Price
 {
-    protected $casts = [
+    protected array $casts = [
         'expires_at' => 'datetime',
     ];
 }

--- a/tests/Stubs/ExpirablePrice.php
+++ b/tests/Stubs/ExpirablePrice.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mongolid\Tests\Stubs;
+
+use DateTime;
+
+class ExpirablePrice extends Price
+{
+    protected $casts = [
+        'expires_at' => 'datetime',
+    ];
+}

--- a/tests/Unit/Model/Casts/CastResolverTest.php
+++ b/tests/Unit/Model/Casts/CastResolverTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Mongolid\Model\Casts;
+
+use Mongolid\Model\Casts\DateTime\DateTimeCast;
+use Mongolid\Model\Casts\DateTime\ImmutableDateTimeCast;
+use Mongolid\Model\Casts\Exceptions\InvalidCastException;
+use Mongolid\TestCase;
+
+class CastResolverTest extends TestCase
+{
+    public function testShouldResolveCast(): void
+    {
+        // Actions
+        $dateTimeCast = CastResolver::resolve('datetime');
+        $dateTimeImmutableCast = CastResolver::resolve('immutable_datetime');
+
+        // Assertions
+        $this->assertInstanceOf(DateTimeCast::class, $dateTimeCast);
+        $this->assertInstanceOf(ImmutableDateTimeCast::class, $dateTimeImmutableCast);
+    }
+
+    public function testShouldThrowExceptionWhenGivenInvalidCastToBeResolved(): void
+    {
+        // Expectations
+        $this->expectException(InvalidCastException::class);
+        $this->expectExceptionMessage('Invalid cast attribute: invalid. Use a valid one like datetime,immutable_datetime');
+
+        // Actions
+        CastResolver::resolve('invalid');
+    }
+}

--- a/tests/Unit/Model/Casts/CastResolverTest.php
+++ b/tests/Unit/Model/Casts/CastResolverTest.php
@@ -20,6 +20,17 @@ class CastResolverTest extends TestCase
         $this->assertInstanceOf(ImmutableDateTimeCast::class, $dateTimeImmutableCast);
     }
 
+    public function testShouldResolveFromCache(): void
+    {
+        // Actions
+        $dateTimeCast = CastResolver::resolve('datetime');
+        $secondDateTimeCast = CastResolver::resolve('datetime');
+
+        // Assertions
+        $this->assertInstanceOf(DateTimeCast::class, $dateTimeCast);
+        $this->assertInstanceOf(DateTimeCast::class, $secondDateTimeCast);
+    }
+
     public function testShouldThrowExceptionWhenGivenInvalidCastToBeResolved(): void
     {
         // Expectations

--- a/tests/Unit/Model/Casts/DateTime/BaseDateTimeCastTest.php
+++ b/tests/Unit/Model/Casts/DateTime/BaseDateTimeCastTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mongolid\Model\Casts\DateTime;
+
+use DateTime;
+use MongoDB\BSON\UTCDateTime;
+use Mongolid\TestCase;
+
+class BaseDateTimeCastTest extends TestCase
+{
+    public function testShouldSet(): void
+    {
+        // Set
+        $dateInDateTime = DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45');
+
+        // Actions
+        $expires_at = DateTimeCast::set($dateInDateTime);
+        $nulled_at = DateTimeCast::set(null);
+        $restored_at = DateTimeCast::set(
+            new UTCDateTime($dateInDateTime)
+        );
+
+        // Assertions
+        $this->assertInstanceOf(UTCDateTime::class, $expires_at);
+        $this->assertInstanceOf(UTCDateTime::class, $restored_at);
+        $this->assertNull($nulled_at);
+    }
+}

--- a/tests/Unit/Model/Casts/DateTime/BaseDateTimeCastTest.php
+++ b/tests/Unit/Model/Casts/DateTime/BaseDateTimeCastTest.php
@@ -12,11 +12,12 @@ class BaseDateTimeCastTest extends TestCase
     {
         // Set
         $dateInDateTime = DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45');
+        $dateTimeCast = new DateTimeCast();
 
         // Actions
-        $expires_at = DateTimeCast::set($dateInDateTime);
-        $nulled_at = DateTimeCast::set(null);
-        $restored_at = DateTimeCast::set(
+        $expires_at = $dateTimeCast->set($dateInDateTime);
+        $nulled_at = $dateTimeCast->set(null);
+        $restored_at = $dateTimeCast->set(
             new UTCDateTime($dateInDateTime)
         );
 

--- a/tests/Unit/Model/Casts/DateTime/DateTimeCastTest.php
+++ b/tests/Unit/Model/Casts/DateTime/DateTimeCastTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mongolid\Model\Casts\DateTime;
+
+use DateTime;
+use MongoDB\BSON\UTCDateTime;
+use Mongolid\TestCase;
+
+class DateTimeCastTest extends TestCase
+{
+    public function testShouldGet(): void
+    {
+        // Set
+        $timestamp = new UTCDateTime(
+            DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45')
+        );
+
+        // Actions
+        $revoked_at = DateTimeCast::get(null);
+        $expires_at = DateTimeCast::get($timestamp);
+        $validated_at = DateTimeCast::get($timestamp);
+
+        // Assertions
+        $this->assertNull($revoked_at);
+        $this->assertInstanceOf(DateTime::class, $expires_at);
+        $this->assertInstanceOf(DateTime::class, $validated_at);
+    }
+}

--- a/tests/Unit/Model/Casts/DateTime/DateTimeCastTest.php
+++ b/tests/Unit/Model/Casts/DateTime/DateTimeCastTest.php
@@ -14,11 +14,12 @@ class DateTimeCastTest extends TestCase
         $timestamp = new UTCDateTime(
             DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45')
         );
+        $dateTimeCast = new DateTimeCast();
 
         // Actions
-        $revoked_at = DateTimeCast::get(null);
-        $expires_at = DateTimeCast::get($timestamp);
-        $validated_at = DateTimeCast::get($timestamp);
+        $revoked_at = $dateTimeCast->get(null);
+        $expires_at = $dateTimeCast->get($timestamp);
+        $validated_at = $dateTimeCast->get($timestamp);
 
         // Assertions
         $this->assertNull($revoked_at);

--- a/tests/Unit/Model/Casts/DateTime/ImmutableDateTimeCastTest.php
+++ b/tests/Unit/Model/Casts/DateTime/ImmutableDateTimeCastTest.php
@@ -14,11 +14,12 @@ class ImmutableDateTimeCastTest extends TestCase
         $timestamp = new UTCDateTime(
             DateTimeImmutable::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45')
         );
+        $immutableDateTimeCast = new ImmutableDateTimeCast();
 
         // Actions
-        $revoked_at = ImmutableDateTimeCast::get(null);
-        $birthdate = ImmutableDateTimeCast::get($timestamp);
-        $created_at = ImmutableDateTimeCast::get($timestamp);
+        $revoked_at = $immutableDateTimeCast->get(null);
+        $birthdate = $immutableDateTimeCast->get($timestamp);
+        $created_at = $immutableDateTimeCast->get($timestamp);
 
         // Assertions
         $this->assertNull($revoked_at);

--- a/tests/Unit/Model/Casts/DateTime/ImmutableDateTimeCastTest.php
+++ b/tests/Unit/Model/Casts/DateTime/ImmutableDateTimeCastTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mongolid\Model\Casts\DateTime;
+
+use DateTimeImmutable;
+use MongoDB\BSON\UTCDateTime;
+use Mongolid\TestCase;
+
+class ImmutableDateTimeCastTest extends TestCase
+{
+    public function testShouldGet(): void
+    {
+        // Set
+        $timestamp = new UTCDateTime(
+            DateTimeImmutable::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45')
+        );
+
+        // Actions
+        $revoked_at = ImmutableDateTimeCast::get(null);
+        $birthdate = ImmutableDateTimeCast::get($timestamp);
+        $created_at = ImmutableDateTimeCast::get($timestamp);
+
+        // Assertions
+        $this->assertNull($revoked_at);
+        $this->assertInstanceOf(DateTimeImmutable::class, $birthdate);
+        $this->assertInstanceOf(DateTimeImmutable::class, $created_at);
+    }
+}

--- a/tests/Unit/Model/HasAttributesTraitTest.php
+++ b/tests/Unit/Model/HasAttributesTraitTest.php
@@ -389,7 +389,7 @@ final class HasAttributesTraitTest extends TestCase
         // Set
         $model = new class() extends AbstractModel
         {
-            protected $casts = [
+            protected array $casts = [
                 'expires_at' => 'datetime',
                 'birthdate' => 'immutable_datetime',
             ];
@@ -415,7 +415,7 @@ final class HasAttributesTraitTest extends TestCase
         // Set
         $model = new class() extends AbstractModel
         {
-            protected $casts = [
+            protected array $casts = [
                 'expires_at' => 'datetime',
                 'birthdate' => 'immutable_datetime',
             ];

--- a/tests/Unit/Model/HasAttributesTraitTest.php
+++ b/tests/Unit/Model/HasAttributesTraitTest.php
@@ -1,7 +1,10 @@
 <?php
 namespace Mongolid\Model;
 
+use DateTime;
+use DateTimeImmutable;
 use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\UTCDateTime;
 use Mongolid\TestCase;
 use Mongolid\Tests\Stubs\PolymorphedReferencedUser;
 use Mongolid\Tests\Stubs\ReferencedUser;
@@ -379,6 +382,51 @@ final class HasAttributesTraitTest extends TestCase
         // Assertions
         $this->assertTrue(isset($model->name));
         $this->assertFalse(isset($model->nonexistant));
+    }
+
+    public function testShouldCastAttributeToDateTimeWhenLoadingFromDatabase(): void
+    {
+        // Set
+        $model = new class() extends AbstractModel
+        {
+            protected $casts = [
+                'expires_at' => 'datetime',
+                'birthdate' => 'immutable_datetime',
+            ];
+
+        };
+        $model->expires_at = new UTCDateTime(
+            DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45')
+        );
+        $model->birthdate = new UTCDateTime(
+            DateTimeImmutable::createFromFormat('d/m/Y', '02/04/1990')
+        );
+
+        // Assertions
+        $this->assertInstanceOf(DateTime::class, $model->expires_at);
+        $this->assertSame('08/10/2025 12:30:45', $model->expires_at->format('d/m/Y H:i:s'));
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $model->birthdate);
+        $this->assertSame('02/04/1990', $model->birthdate->format('d/m/Y'));
+    }
+
+    public function testShouldCastAttributeToUTCDateTimeWhenSettingAttributes(): void
+    {
+        // Set
+        $model = new class() extends AbstractModel
+        {
+            protected $casts = [
+                'expires_at' => 'datetime',
+                'birthdate' => 'immutable_datetime',
+            ];
+        };
+
+        // Actions
+        $model->expires_at = DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45');
+
+        // Assertions
+        $this->assertInstanceOf(UTCDateTime::class, $model->getDocumentAttributes()['expires_at']);
+        $this->assertInstanceOf(DateTime::class, $model->expires_at);
     }
 
     public function getFillableOptions(): array


### PR DESCRIPTION
This PR adds a new feature on mongolid to allow cast properties to DateTime when retrieving it from database. 

It also adds a documentation for this feature:

![image](https://github.com/leroy-merlin-br/mongolid/assets/974859/fbb248bd-3f5c-4a6f-9f54-34168ec59707)

