### PR TITLE
feat: add refresh method

### DIFF
--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -184,6 +184,15 @@ abstract class AbstractModel implements ModelInterface
     }
 
     /**
+     * Query model on database to retrieve an updated version of its attributes.
+     * @return self
+     */
+    public function refresh(): self
+    {
+        return $this->first($this->_id);
+    }
+
+    /**
      * Dynamically retrieve attributes on the model.
      *
      * @param string $key name of the attribute

--- a/tests/Integration/PersistedDataTest.php
+++ b/tests/Integration/PersistedDataTest.php
@@ -134,6 +134,22 @@ final class PersistedDataTest extends IntegrationTestCase
         $this->assertEquals($expected, $result->toArray());
     }
 
+    public function testRefreshModel(): void
+    {
+        // Set
+        $user = $this->getUser(true);
+        $user->name = 'Jane Doe';
+
+        // Actions
+        $result = $user->refresh();
+
+        // Assertions
+        /**
+         * In this test, User must have his old name after refresh because its model wasn't persisted after setting its name to Jane Doe.
+         */
+        $this->assertSame('John Doe', $result->name);
+    }
+
     private function getUser(bool $save = false): ReferencedUser
     {
         $user = new ReferencedUser();

--- a/tests/Unit/Model/AbstractModelTest.php
+++ b/tests/Unit/Model/AbstractModelTest.php
@@ -2,6 +2,7 @@
 namespace Mongolid\Model;
 
 use Mockery as m;
+use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Persistable;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -587,5 +588,24 @@ final class AbstractModelTest extends TestCase
 
         // Assertions
         $this->assertSame('MY AWESOME NAME', $result);
+    }
+
+    public function testShouldRefreshModels(): void
+    {
+        // Set
+        $builder = $this->instance(Builder::class, m::mock(Builder::class));
+        $this->model->_id = 'some-id-value';
+
+        // Expectations
+        $builder
+            ->expects('first')
+            ->with(m::type(get_class($this->model)), 'some-id-value', [], false)
+            ->andReturn($this->model);
+
+        // Actions
+        $result = $this->model->refresh();
+
+        // Assertions
+        $this->assertSame($this->model, $result);
     }
 }


### PR DESCRIPTION
This PR adds a `refresh()` method to reload a model in database. 

This method can be useful in Integration Tests, when it is desired to query an object again in Database in order to check if it was rightfully persisted.

Also, this was a long requested feature by Boitata team.
- https://github.com/leroy-merlin-br/mongolid/issues/40
- https://github.com/leroy-merlin-br/kameleon/pull/18489#discussion_r1312121509