### PR TITLE
feat: add refresh method on legacy model

### DIFF
--- a/docs/docs/operations.md
+++ b/docs/docs/operations.md
@@ -38,3 +38,12 @@ To delete a model, simply call the `delete` method on the instance:
     
     $post->delete();
 ```
+## Reload a model from database
+
+You can reload an instance from database by using `refresh()` method:
+
+```php
+    $post = Post::first('4af9f23d8ead0e1d32000000');
+
+    $updatedPost = $post->refresh();
+```

--- a/src/LegacyRecord.php
+++ b/src/LegacyRecord.php
@@ -399,4 +399,13 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
 
         $this->syncOriginalDocumentAttributes();
     }
+
+    /**
+     * Query model on database to retrieve an updated version of its attributes.
+     * @return self
+     */
+    public function refresh(): self
+    {
+        return $this->first($this->_id);
+    }
 }

--- a/src/LegacyRecord.php
+++ b/src/LegacyRecord.php
@@ -402,7 +402,6 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
 
     /**
      * Query model on database to retrieve an updated version of its attributes.
-     * @return self
      */
     public function refresh(): self
     {

--- a/tests/Integration/LegacyRecordTest.php
+++ b/tests/Integration/LegacyRecordTest.php
@@ -55,4 +55,26 @@ class LegacyRecordTest extends IntegrationTestCase
 
         $this->assertSame($expected, $entity->getAttributes());
     }
+
+    public function testRefreshModel(): void
+    {
+        // Set
+        $entity = new LegacyRecordUser();
+        $entity->dynamic = true;
+        $entity->fill([
+            'name' => 'John Doe',
+        ]);
+        $entity->save();
+
+        // Actions
+        $entity->name = 'Jane Doe';
+        $entity = $entity->refresh();
+
+        // Assertions
+        /**
+         * In this test, User must have his old name after refresh because its model wasn't persisted after setting its name to Jane Doe.
+         */
+        $this->assertInstanceOf(LegacyRecordUser::class, $entity);
+        $this->assertSame('John Doe', $entity->name);
+    }
 }

--- a/tests/Unit/LegacyRecordTest.php
+++ b/tests/Unit/LegacyRecordTest.php
@@ -437,4 +437,31 @@ class LegacyRecordTest extends TestCase
         $this->entity->setWriteConcern(0);
         $this->assertEquals(0, $this->entity->getWriteConcern());
     }
+
+    public function testShouldRefreshModels(): void
+    {
+        // Set
+        $id = 'some-id-value';
+        $entity = m::mock(LegacyRecord::class.'[getDataMapper]');
+        $this->setProtected($entity, 'collection', 'mongolid');
+        $entity->_id = $id;
+        $dataMapper = m::mock();
+        Container::instance(get_class($entity), $entity);
+
+        // Expectations
+        $entity->shouldReceive('getDataMapper')
+            ->andReturn($dataMapper);
+
+        $dataMapper->shouldReceive('first')
+            ->once()
+            ->with('some-id-value', [], false)
+            ->andReturn($entity);
+
+        // Actions
+        $result = $entity->refresh();
+
+        // Assertions
+        $this->assertSame($entity, $result);
+    }
+
 }


### PR DESCRIPTION
This PR continues the work done in https://github.com/leroy-merlin-br/mongolid/pull/221.

It adds refresh method on LegacyRecord for retrocompability with Legacy Mongolid Models. 