### PR TITLE
feat: add backed enum cast

### DIFF
--- a/docs/docs/casting.md
+++ b/docs/docs/casting.md
@@ -38,7 +38,38 @@ $user->getOriginalDocumentAttributes()['birthdate']; // Returns birthdate as an 
 // To set a new birthdate, you can pass both UTCDateTime or native's PHP DateTime
 $user->birthdate = new \MongoDB\BSON\UTCDateTime($anyDateTime);
 $user->birthdate = DateTime::createFromFormat('d/m/Y', '01/03/1970');
-
-
 ```
 
+## Casting to Enum with backing value (aka BackedEnum)
+
+With Mongolid, you can define attributes to be cast to enum using `$casts` property in your models. 
+
+```php
+enum Size: string
+{
+    case Small = 'small';
+    case Big = 'big';
+}
+
+class Box extends \Mongolid\Model\AbstractModel {
+    protected $casts = [
+        'box_size' => Size::class,
+    ];
+}
+```
+
+When you define an attribute to be cast as a enum type, Mongolid will load it from database will do its trick to return an enum instance anytime you try to access it with property accessor operator (`->`).
+
+If you need to manipulate its raw value, then you can access it through `getDocumentAttributes()` method.
+
+To write a value on an attribute with enum cast, you should pass the enum instance like `Size::Small`
+Internally, Mongolid will manage to set the property as enum backing value.
+
+Check out some usages and examples:
+
+```php
+$box = Box::first();
+$box->box_size = Size::Small; // Set box_size with enum instance
+$box->box_size; // Returns box_size as enum instance
+$box->getDocumentAttributes()['box_size']; // Returns box_size backing value
+```

--- a/src/DataMapper/DataMapper.php
+++ b/src/DataMapper/DataMapper.php
@@ -372,14 +372,22 @@ class DataMapper implements HasSchemaInterface
     {
         $schemaMapper = $this->getSchemaMapper();
         $parsedDocument = $schemaMapper->map($entity);
-
         if (is_object($entity)) {
+            $setter = $this->getAttributeSetter($entity);
+
             foreach ($parsedDocument as $field => $value) {
-                $entity->$field = $value;
+                $setter($field, $value);
             }
         }
 
         return $parsedDocument;
+    }
+
+    private function getAttributeSetter($entity): callable
+    {
+        return $entity instanceof ModelInterface
+            ? fn ($field, $value) => $entity->setDocumentAttribute($field, $value)
+            : fn ($field, $value) => $entity->$field = $value;
     }
 
     /**

--- a/src/DataMapper/DataMapper.php
+++ b/src/DataMapper/DataMapper.php
@@ -386,8 +386,8 @@ class DataMapper implements HasSchemaInterface
     private function getAttributeSetter($entity): callable
     {
         return $entity instanceof ModelInterface
-            ? fn ($field, $value) => $entity->setDocumentAttribute($field, $value)
-            : fn ($field, $value) => $entity->$field = $value;
+            ? fn (string $field, mixed $value) => $entity->setDocumentAttribute($field, $value)
+            : fn (string $field, mixed $value) => $entity->$field = $value;
     }
 
     /**

--- a/src/DataMapper/EntityAssembler.php
+++ b/src/DataMapper/EntityAssembler.php
@@ -4,8 +4,8 @@ namespace Mongolid\DataMapper;
 
 use Mongolid\Container\Container;
 use Mongolid\Model\ModelInterface;
-use Mongolid\Schema\Schema;
 use Mongolid\Model\PolymorphableModelInterface;
+use Mongolid\Schema\Schema;
 
 /**
  * EntityAssembler have the responsibility of assembling the data coming from
@@ -32,6 +32,7 @@ class EntityAssembler
     {
         $entityClass = $schema->entityClass;
         $model = Container::make($entityClass);
+        $setter = $this->getAttributeSetter($model);
 
         foreach ($document as $field => $value) {
             $fieldType = $schema->fields[$field] ?? null;
@@ -40,12 +41,19 @@ class EntityAssembler
                 $value = $this->assembleDocumentsRecursively($value, substr($fieldType, 7));
             }
 
-            $model->$field = $value;
+            $setter($field, $value);
         }
 
         $entity = $this->morphingTime($model);
 
         return $this->prepareOriginalAttributes($entity);
+    }
+
+    private function getAttributeSetter($model): callable
+    {
+        return $model instanceof ModelInterface
+            ? fn ($field, $value) => $model->setDocumentAttribute($field, $value)
+            : fn ($field, $value) => $model->$field = $value;
     }
 
     /**

--- a/src/DataMapper/EntityAssembler.php
+++ b/src/DataMapper/EntityAssembler.php
@@ -52,8 +52,8 @@ class EntityAssembler
     private function getAttributeSetter($model): callable
     {
         return $model instanceof ModelInterface
-            ? fn ($field, $value) => $model->setDocumentAttribute($field, $value)
-            : fn ($field, $value) => $model->$field = $value;
+            ? fn (string $field, mixed $value) => $model->setDocumentAttribute($field, $value)
+            : fn (string $field, mixed $value) => $model->$field = $value;
     }
 
     /**

--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -281,7 +281,14 @@ abstract class AbstractModel implements ModelInterface
     public function bsonUnserialize(array $data): void
     {
         unset($data['__pclass']);
-        static::fill($data, $this, true);
+
+        foreach ($data as $key => $value) {
+            if ($value instanceof \stdClass) {
+                $value = json_decode(json_encode($value), true); // cast to array
+            }
+
+            $this->attributes[$key] = $value;
+        }
 
         $this->syncOriginalDocumentAttributes();
     }

--- a/src/Model/Casts/BackedEnumCast.php
+++ b/src/Model/Casts/BackedEnumCast.php
@@ -15,7 +15,6 @@ class BackedEnumCast implements CastInterface
     ) {
     }
 
-
     /**
      * @param int|string|null $value
      */

--- a/src/Model/Casts/BackedEnumCast.php
+++ b/src/Model/Casts/BackedEnumCast.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Mongolid\Model\Casts;
+
+use BackedEnum;
+use Mongolid\Model\Casts\Exceptions\InvalidTypeException;
+
+class BackedEnumCast implements CastInterface
+{
+    /**
+     * @param class-string<BackedEnum> $backedEnum
+     */
+    public function __construct(
+        private string $backedEnum
+    ) {
+    }
+
+
+    /**
+     * @param int|string|null $value
+     */
+    public function get(mixed $value): ?BackedEnum
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        return ($this->backedEnum)::from($value);
+    }
+
+    /**
+     * @param BackedEnum|string|int|null $value
+     */
+    public function set(mixed $value): string|int|null
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (!$value instanceof $this->backedEnum) {
+            throw new InvalidTypeException(
+                "$this->backedEnum|null",
+                $value
+            );
+        }
+
+        return $value->value;
+    }
+}

--- a/src/Model/Casts/CastResolver.php
+++ b/src/Model/Casts/CastResolver.php
@@ -2,6 +2,7 @@
 
 namespace Mongolid\Model\Casts;
 
+use BackedEnum;
 use Mongolid\Model\Casts\DateTime\DateTimeCast;
 use Mongolid\Model\Casts\DateTime\ImmutableDateTimeCast;
 use Mongolid\Model\Casts\Exceptions\InvalidCastException;
@@ -27,7 +28,9 @@ class CastResolver
         self::$cache[$castName] = match($castName) {
             self::DATE_TIME => new DateTimeCast(),
             self::IMMUTABLE_DATE_TIME => new ImmutableDateTimeCast(),
-            default => throw new InvalidCastException($castName),
+            default => is_subclass_of($castName, BackedEnum::class)
+                ? new BackedEnumCast($castName)
+                : throw new InvalidCastException($castName),
         };
 
         return self::$cache[$castName];

--- a/src/Model/Casts/Exceptions/InvalidCastException.php
+++ b/src/Model/Casts/Exceptions/InvalidCastException.php
@@ -3,14 +3,12 @@
 namespace Mongolid\Model\Casts\Exceptions;
 
 use InvalidArgumentException;
-use Mongolid\Model\Casts\CastResolver;
 
 class InvalidCastException extends InvalidArgumentException
 {
     public function __construct(string $cast)
     {
-        $available = implode(',', CastResolver::$validCasts);
-        $message = "Invalid cast attribute: $cast. Use a valid one like $available";
+        $message = "Invalid cast attribute: $cast";
 
         parent::__construct($message);
     }

--- a/src/Model/Casts/Exceptions/InvalidTypeException.php
+++ b/src/Model/Casts/Exceptions/InvalidTypeException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mongolid\Model\Casts\Exceptions;
+
+use InvalidArgumentException;
+use Mongolid\Model\Casts\CastResolver;
+
+class InvalidTypeException extends InvalidArgumentException
+{
+    public function __construct(string $expectedType, mixed $value)
+    {
+        $invalidType = is_object($value)
+            ? $value::class
+            : gettype($value);
+
+        parent::__construct("Value expected type $expectedType, given $invalidType");
+    }
+}

--- a/src/Model/HasAttributesTrait.php
+++ b/src/Model/HasAttributesTrait.php
@@ -79,6 +79,7 @@ trait HasAttributesTrait
         HasAttributesInterface $object = null,
         bool $force = false
     ): HasAttributesInterface {
+
         if (!$object) {
             $object = Container::make(static::class);
         }

--- a/src/Model/HasLegacyAttributesTrait.php
+++ b/src/Model/HasLegacyAttributesTrait.php
@@ -71,12 +71,6 @@ trait HasLegacyAttributesTrait
     {
         $inAttributes = array_key_exists($key, $this->attributes);
 
-        if ($casterName = $this->casts[$key] ?? null) {
-            $caster = CastResolver::resolve($casterName);
-
-            return $caster->get($this->attributes[$key] ?? null);
-        }
-
         if ($inAttributes) {
             return $this->attributes[$key];
         } elseif ('attributes' == $key) {
@@ -135,11 +129,6 @@ trait HasLegacyAttributesTrait
      */
     public function setAttribute(string $key, $value)
     {
-        if ($casterName = $this->casts[$key] ?? null) {
-            $caster = CastResolver::resolve($casterName);
-            $value = $caster->set($value);
-        }
-
         $this->attributes[$key] = $value;
     }
 
@@ -214,6 +203,12 @@ trait HasLegacyAttributesTrait
             return $this->{$this->buildMutatorMethod($key, 'get')}();
         }
 
+        if ($casterName = $this->casts[$key] ?? null) {
+            $caster = CastResolver::resolve($casterName);
+
+            return $caster->get($this->attributes[$key] ?? null);
+        }
+
         return $this->getAttribute($key);
     }
 
@@ -227,6 +222,11 @@ trait HasLegacyAttributesTrait
     {
         if ($this->mutable && $this->hasMutatorMethod($key, 'set')) {
             $value = $this->{$this->buildMutatorMethod($key, 'set')}($value);
+        }
+
+        if ($casterName = $this->casts[$key] ?? null) {
+            $caster = CastResolver::resolve($casterName);
+            $value = $caster->set($value);
         }
 
         $this->setAttribute($key, $value);

--- a/tests/Integration/BackedEnumCastTest.php
+++ b/tests/Integration/BackedEnumCastTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Mongolid\Tests\Integration;
+
+use Mongolid\Tests\Stubs\Box;
+use Mongolid\Tests\Stubs\Legacy\Box as LegacyBox;
+use Mongolid\Tests\Stubs\Size;
+
+/**
+ * @requires PHP >= 8.1
+ */
+class BackedEnumCastTest extends IntegrationTestCase
+{
+    public function testShouldCreateAndSaveBoxWithCastedAttributes(): void
+    {
+        // Set
+        $box = new Box();
+        $box->box_size = Size::Big;
+
+        // Actions
+        $box->save();
+
+        // Assertions
+        $this->assertEquals(Size::Big, $box->box_size);
+        $this->assertEquals(
+            'big',
+            $box->getOriginalDocumentAttributes()['box_size']
+        );
+    }
+
+    public function testShouldUpdateBoxWithCastedAttributes(): void
+    {
+        // Set
+        $box = new Box();
+        $box->box_size = Size::Small;
+
+        // Actions
+        $box->update();
+
+        // Assertions
+        $this->assertEquals(Size::Small, $box->box_size);
+        $this->assertEquals(
+            'small',
+            $box->getOriginalDocumentAttributes()['box_size']
+        );
+    }
+
+    public function testShouldCreateAndSaveLegacyBoxWithCastedAttributes(): void
+    {
+        // Set
+        $legacyBox = new LegacyBox();
+        $legacyBox->box_size = Size::Big;
+
+        // Actions
+        $legacyBox->save();
+
+        // Assertions
+        $this->assertEquals(Size::Big, $legacyBox->box_size);
+        $this->assertEquals(
+            'big',
+            $legacyBox->getOriginalDocumentAttributes()['box_size']
+        );
+    }
+
+    public function testShouldUpdateLegacyBoxWithCastedAttributes(): void
+    {
+        // Set
+        $legacyBox = new LegacyBox();
+        $legacyBox->box_size = Size::Small;
+
+        // Actions
+        $legacyBox->save();
+
+        // Assertions
+        $this->assertEquals(Size::Small, $legacyBox->box_size);
+        $this->assertEquals(
+            'small',
+            $legacyBox->getOriginalDocumentAttributes()['box_size']
+        );
+    }
+}

--- a/tests/Integration/PolymorphableModelTest.php
+++ b/tests/Integration/PolymorphableModelTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Mongolid\Tests\Integration;
+
+use DateTime;
+use MongoDB\BSON\UTCDateTime;
+use Mongolid\Tests\Stubs\PolymorphedReferencedUser;
+use Mongolid\Tests\Stubs\ReferencedUser;
+
+class PolymorphableModelTest extends IntegrationTestCase
+{
+    public function testShoudlRetrivePolymorphedModelFromFill(): void
+    {
+        // Set
+        $polymorphedUserData = [
+            'type' => 'polymorphed',
+            'new_field' => true,
+        ];
+
+        // Actions
+        $polymorphedUser = ReferencedUser::fill($polymorphedUserData);
+
+        // Assertions
+        $this->assertSame(PolymorphedReferencedUser::class, $polymorphedUser::class);
+        $this->assertSame('polymorphed', $polymorphedUser->type);
+        $this->assertTrue($polymorphedUser->new_field);
+    }
+
+    public function testShoudlRetrivePolymorphedModelFromDatabase(): void
+    {
+        // Set
+        $polymorphedUser = ReferencedUser::fill([
+            'type' => 'polymorphed',
+            'new_field' => true,
+        ]);
+        $polymorphedUser->save();
+
+        // Actions
+        $polymorphedUserFromDatabase = ReferencedUser::first();
+
+        // Assertions
+        $this->assertSame(PolymorphedReferencedUser::class, $polymorphedUserFromDatabase::class);
+        $this->assertSame('polymorphed', $polymorphedUserFromDatabase->type);
+        $this->assertTrue($polymorphedUserFromDatabase->new_field);
+    }
+
+    /**
+     *  Mongolid uses the 'unserialize' feature of the MongoDB extension to create a model instance from the database.
+     *  However, in the current implementation, changing the model instance based on the PolymorphInterface is not possible.
+     *  To ensure the expected behavior, consider creating the model with the desired type (possibly using the 'fill' method) before saving it.
+     */
+    public function testShouldRetrieveFromDatabaseAndNotRespectPolymorphInterface(): void
+    {
+        // Set
+        $user = new ReferencedUser();
+        $user->type = 'polymorphed';
+        $user->some_date = new UTCDateTime(new DateTime('2018-10-10 00:00:00'));
+        $user->save();
+
+        // Actions
+        $userFromDatabase = ReferencedUser::first();
+
+        // Assertions
+        $this->assertSame(ReferencedUser::class, $userFromDatabase::class);
+        $this->assertEquals($user->some_date->toDateTime(), $userFromDatabase->some_date?->toDateTime());
+        $this->assertSame($user->type, $userFromDatabase->type);
+    }
+}

--- a/tests/Stubs/Box.php
+++ b/tests/Stubs/Box.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mongolid\Tests\Stubs;
+
+use Mongolid\Model\AbstractModel;
+
+class Box extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    protected $collection = 'boxes';
+
+    protected array $casts = [
+        'box_size' => Size::class,
+    ];
+}

--- a/tests/Stubs/Legacy/Box.php
+++ b/tests/Stubs/Legacy/Box.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mongolid\Tests\Stubs\Legacy;
+
+use Mongolid\LegacyRecord;
+use Mongolid\Tests\Stubs\Size;
+
+class Box extends LegacyRecord
+{
+    /**
+     * @var string
+     */
+    protected $collection = 'boxes';
+
+    protected array $casts = [
+        'box_size' => Size::class,
+    ];
+}

--- a/tests/Stubs/Size.php
+++ b/tests/Stubs/Size.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Mongolid\Tests\Stubs;
+
+enum Size: string
+{
+    case Small = 'small';
+    case Big = 'big';
+}

--- a/tests/Unit/Model/Casts/BackedEnumCastTest.php
+++ b/tests/Unit/Model/Casts/BackedEnumCastTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Mongolid\Model\Casts;
+
+use Mongolid\Model\Casts\Exceptions\InvalidTypeException;
+use Mongolid\TestCase;
+use Mongolid\Tests\Stubs\Size;
+use ValueError;
+
+/**
+ * @requires PHP >= 8.1
+ */
+class BackedEnumCastTest extends TestCase
+{
+    public function testShouldGetValue(): void
+    {
+        // Set
+        $cast = new BackedEnumCast(Size::class);
+
+        // Actions
+        $result = $cast->get('small');
+
+        // Asserts
+        $this->assertEquals(Size::Small, $result);
+    }
+
+    public function testShouldGetNull(): void
+    {
+        // Set
+        $cast = new BackedEnumCast(Size::class);
+
+        // Actions
+        $result = $cast->get(null);
+
+        // Asserts
+        $this->assertNull($result);
+    }
+
+    public function testShoulThrowErrorWhenGetWithUnknownValue(): void
+    {
+        // Set
+        $cast = new BackedEnumCast(Size::class);
+
+        // Expects
+        $this->expectException(ValueError::class);
+
+        // Actions
+        $cast->get('unknow value');
+    }
+
+    public function testShouldSet(): void
+    {
+        // Set
+        $cast = new BackedEnumCast(Size::class);
+
+        // Actions
+        $result = $cast->set(Size::Big);
+
+        // Asserts
+        $this->assertEquals('big', $result);
+    }
+
+    public function testShouldSetNull(): void
+    {
+        // Set
+        $cast = new BackedEnumCast(Size::class);
+
+        // Actions
+        $result = $cast->set(null);
+
+        // Asserts
+        $this->assertNull($result);
+    }
+
+    public function testShouldThrowErrorWhenSetWithUnknownValue(): void
+    {
+        // Set
+        $cast = new BackedEnumCast(Size::class);
+
+        // Expectations
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage(
+            'Value expected type ' . Size::class . '|null, given string'
+        );
+
+        // Actions
+        $cast->set('unknow value');
+    }
+}

--- a/tests/Unit/Model/Casts/CastResolverTest.php
+++ b/tests/Unit/Model/Casts/CastResolverTest.php
@@ -6,6 +6,7 @@ use Mongolid\Model\Casts\DateTime\DateTimeCast;
 use Mongolid\Model\Casts\DateTime\ImmutableDateTimeCast;
 use Mongolid\Model\Casts\Exceptions\InvalidCastException;
 use Mongolid\TestCase;
+use Mongolid\Tests\Stubs\Size;
 
 class CastResolverTest extends TestCase
 {
@@ -17,7 +18,22 @@ class CastResolverTest extends TestCase
 
         // Assertions
         $this->assertInstanceOf(DateTimeCast::class, $dateTimeCast);
-        $this->assertInstanceOf(ImmutableDateTimeCast::class, $dateTimeImmutableCast);
+        $this->assertInstanceOf(
+            ImmutableDateTimeCast::class,
+            $dateTimeImmutableCast
+        );
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testShouldResolveBackedEnumCast(): void
+    {
+        // Actions
+        $backedEnumCast = CastResolver::resolve(Size::class);
+
+        // Assertions
+        $this->assertInstanceOf(BackedEnumCast::class, $backedEnumCast);
     }
 
     public function testShouldResolveFromCache(): void
@@ -35,7 +51,7 @@ class CastResolverTest extends TestCase
     {
         // Expectations
         $this->expectException(InvalidCastException::class);
-        $this->expectExceptionMessage('Invalid cast attribute: invalid. Use a valid one like datetime,immutable_datetime');
+        $this->expectExceptionMessage('Invalid cast attribute: invalid');
 
         // Actions
         CastResolver::resolve('invalid');


### PR DESCRIPTION
This PR adds a new feature on mongolid to allow cast properties to enum when retrieving it from database.

It also adds a documentation for this feature:

![image](https://github.com/leroy-merlin-br/mongolid/assets/974859/32212779-ba25-4499-8c0d-851179b75a44)
