### PR TITLE
chore: rename fresh method

### DIFF
--- a/docs/docs/operations.md
+++ b/docs/docs/operations.md
@@ -40,10 +40,10 @@ To delete a model, simply call the `delete` method on the instance:
 ```
 ## Reload a model from database
 
-You can reload an instance from database by using `refresh()` method:
+You can reload an instance from database by using `fresh()` method:
 
 ```php
     $post = Post::first('4af9f23d8ead0e1d32000000');
 
-    $updatedPost = $post->refresh();
+    $updatedPost = $post->fresh();
 ```

--- a/src/LegacyRecord.php
+++ b/src/LegacyRecord.php
@@ -403,7 +403,7 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
     /**
      * Query model on database to retrieve an updated version of its attributes.
      */
-    public function refresh(): self
+    public function fresh(): self
     {
         return $this->first($this->_id);
     }

--- a/src/Model/AbstractModel.php
+++ b/src/Model/AbstractModel.php
@@ -187,7 +187,7 @@ abstract class AbstractModel implements ModelInterface
      * Query model on database to retrieve an updated version of its attributes.
      * @return self
      */
-    public function refresh(): self
+    public function fresh(): self
     {
         return $this->first($this->_id);
     }

--- a/tests/Integration/LegacyRecordTest.php
+++ b/tests/Integration/LegacyRecordTest.php
@@ -56,7 +56,7 @@ class LegacyRecordTest extends IntegrationTestCase
         $this->assertSame($expected, $entity->getAttributes());
     }
 
-    public function testRefreshModel(): void
+    public function testShouldFreshModel(): void
     {
         // Set
         $entity = new LegacyRecordUser();
@@ -68,7 +68,7 @@ class LegacyRecordTest extends IntegrationTestCase
 
         // Actions
         $entity->name = 'Jane Doe';
-        $entity = $entity->refresh();
+        $entity = $entity->fresh();
 
         // Assertions
         /**

--- a/tests/Integration/PersistedDataTest.php
+++ b/tests/Integration/PersistedDataTest.php
@@ -134,14 +134,14 @@ final class PersistedDataTest extends IntegrationTestCase
         $this->assertEquals($expected, $result->toArray());
     }
 
-    public function testRefreshModel(): void
+    public function testShouldFreshModel(): void
     {
         // Set
         $user = $this->getUser(true);
         $user->name = 'Jane Doe';
 
         // Actions
-        $result = $user->refresh();
+        $result = $user->fresh();
 
         // Assertions
         /**

--- a/tests/Unit/LegacyRecordTest.php
+++ b/tests/Unit/LegacyRecordTest.php
@@ -458,7 +458,7 @@ class LegacyRecordTest extends TestCase
             ->andReturn($entity);
 
         // Actions
-        $result = $entity->refresh();
+        $result = $entity->fresh();
 
         // Assertions
         $this->assertSame($entity, $result);

--- a/tests/Unit/Model/AbstractModelTest.php
+++ b/tests/Unit/Model/AbstractModelTest.php
@@ -590,7 +590,7 @@ final class AbstractModelTest extends TestCase
         $this->assertSame('MY AWESOME NAME', $result);
     }
 
-    public function testShouldRefreshModels(): void
+    public function testShouldFreshModels(): void
     {
         // Set
         $builder = $this->instance(Builder::class, m::mock(Builder::class));
@@ -603,7 +603,7 @@ final class AbstractModelTest extends TestCase
             ->andReturn($this->model);
 
         // Actions
-        $result = $this->model->refresh();
+        $result = $this->model->fresh();
 
         // Assertions
         $this->assertSame($this->model, $result);


### PR DESCRIPTION
This PR renames the `refresh` method to `fresh`

https://github.com/leroy-merlin-br/mongolid/pull/222#pullrequestreview-1689030788

