### PR TITLE
FIX : Connection defaultDatabase

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,11 +12,15 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         mongo:
+          - "3.6"
           - "4.0"
           - "4.2"
           - "4.4"
           - "5.0"
+          - "6.0"
+          - "7.0"
     services:
       mongodb:
         image: mongo:${{ matrix.mongo }}
@@ -30,7 +34,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mongodb-mongodb/mongo-php-driver@1.15.0
+          extensions: mongodb-mongodb/mongo-php-driver@1.17.0
 
       - name: Composer
         uses: ramsey/composer-install@v2

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   php:
     build: docker/php
@@ -9,9 +7,11 @@ services:
       - .:/var/www/html
     environment:
       - DB_HOST=db
+    networks:
+      - mongolid
 
   db:
-    image: mongo:6.0
+    image: mongo:7.0
     command: mongod --wiredTigerCacheSizeGB 0.25
     deploy:
       resources:
@@ -21,6 +21,8 @@ services:
           memory: 512M
     volumes:
       - db:/data/db
+    networks:
+      - mongolid
 
   mkdocs:
     image: polinux/mkdocs
@@ -30,3 +32,6 @@ services:
 volumes:
   db:
     driver: local
+
+networks:
+  mongolid:

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-mongodb": "^1.15.0",
+        "ext-mongodb": "^1.17.0",
         "illuminate/container": "^9.0 || ^10.0",
         "illuminate/support": "^9.0 || ^10.0",
-        "mongodb/mongodb": "~1.15.0"
+        "mongodb/mongodb": "^1.17.0"
     },
     "require-dev": {
         "leroy-merlin-br/coding-standard": "^3.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,89 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "054dfac86bc48cf41c000a9a58dd5405",
+    "content-hash": "50f47c0ffd3e5f1af85f211ee8d387a7",
     "packages": [
         {
-            "name": "doctrine/inflector",
-            "version": "2.0.8",
+            "name": "carbonphp/carbon-doctrine-types",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/inflector.git",
-                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff"
+                "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
+                "reference": "99f76ffa36cce3b70a4a6abce41dba15ca2e84cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
-                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/99f76ffa36cce3b70a4a6abce41dba15ca2e84cb",
+                "reference": "99f76ffa36cce3b70a4a6abce41dba15ca2e84cb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.7.0 || >=4.0.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.7.0",
+                "nesbot/carbon": "^2.71.0 || ^3.0.0",
+                "phpunit/phpunit": "^10.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\Doctrine\\": "src/Carbon/Doctrine/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KyleKatarn",
+                    "email": "kylekatarnls@gmail.com"
+                }
+            ],
+            "description": "Types to use Carbon in Doctrine",
+            "keywords": [
+                "carbon",
+                "date",
+                "datetime",
+                "doctrine",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-11T17:09:12+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc",
                 "shasum": ""
             },
             "require": {
@@ -79,7 +148,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.8"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.10"
             },
             "funding": [
                 {
@@ -95,11 +164,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-16T13:40:37+00:00"
+            "time": "2024-02-18T20:23:39+00:00"
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.52.15",
+            "version": "v9.52.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -154,7 +223,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.52.15",
+            "version": "v9.52.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -200,7 +269,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v9.52.15",
+            "version": "v9.52.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -251,7 +320,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.52.15",
+            "version": "v9.52.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -299,7 +368,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.52.15",
+            "version": "v9.52.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -345,7 +414,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.52.15",
+            "version": "v9.52.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -416,16 +485,16 @@
         },
         {
             "name": "jean85/pretty-package-versions",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Jean85/pretty-package-versions.git",
-                "reference": "ae547e455a3d8babd07b96966b17d7fd21d9c6af"
+                "reference": "f9fdd29ad8e6d024f52678b570e5593759b550b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/ae547e455a3d8babd07b96966b17d7fd21d9c6af",
-                "reference": "ae547e455a3d8babd07b96966b17d7fd21d9c6af",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/f9fdd29ad8e6d024f52678b570e5593759b550b4",
+                "reference": "f9fdd29ad8e6d024f52678b570e5593759b550b4",
                 "shasum": ""
             },
             "require": {
@@ -433,9 +502,9 @@
                 "php": "^7.1|^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.17",
+                "friendsofphp/php-cs-fixer": "^3.2",
                 "jean85/composer-provided-replaced-stub-package": "^1.0",
-                "phpstan/phpstan": "^0.12.66",
+                "phpstan/phpstan": "^1.4",
                 "phpunit/phpunit": "^7.5|^8.5|^9.4",
                 "vimeo/psalm": "^4.3"
             },
@@ -469,42 +538,45 @@
             ],
             "support": {
                 "issues": "https://github.com/Jean85/pretty-package-versions/issues",
-                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.5"
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.6"
             },
-            "time": "2021-10-08T21:21:46+00:00"
+            "time": "2024-03-08T09:58:59+00:00"
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.15.0",
+            "version": "1.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8"
+                "reference": "01d0840bf0678f519e72dc71b69c8a50a0856c2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8",
-                "reference": "3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/01d0840bf0678f519e72dc71b69c8a50a0856c2d",
+                "reference": "01d0840bf0678f519e72dc71b69c8a50a0856c2d",
                 "shasum": ""
             },
             "require": {
                 "ext-hash": "*",
                 "ext-json": "*",
-                "ext-mongodb": "^1.15.0",
-                "jean85/pretty-package-versions": "^1.2 || ^2.0.1",
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-php80": "^1.19"
+                "ext-mongodb": "^1.17.0",
+                "jean85/pretty-package-versions": "^2.0.1",
+                "php": "^7.4 || ^8.0",
+                "psr/log": "^1.1.4|^2|^3",
+                "symfony/polyfill-php80": "^1.27",
+                "symfony/polyfill-php81": "^1.27"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9.0",
-                "squizlabs/php_codesniffer": "^3.6",
+                "doctrine/coding-standard": "^12.0",
+                "rector/rector": "^0.19",
+                "squizlabs/php_codesniffer": "^3.7",
                 "symfony/phpunit-bridge": "^5.2",
-                "vimeo/psalm": "^4.28"
+                "vimeo/psalm": "^5.13"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.15.x-dev"
+                    "dev-master": "1.17.x-dev"
                 }
             },
             "autoload": {
@@ -527,6 +599,10 @@
                 {
                     "name": "Jeremy Mikola",
                     "email": "jmikola@gmail.com"
+                },
+                {
+                    "name": "Jérôme Tamarelle",
+                    "email": "jerome.tamarelle@mongodb.com"
                 }
             ],
             "description": "MongoDB driver library",
@@ -539,25 +615,26 @@
             ],
             "support": {
                 "issues": "https://github.com/mongodb/mongo-php-library/issues",
-                "source": "https://github.com/mongodb/mongo-php-library/tree/1.15.0"
+                "source": "https://github.com/mongodb/mongo-php-library/tree/1.17.1"
             },
-            "time": "2022-11-23T04:45:35+00:00"
+            "time": "2024-03-14T10:33:11+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.69.0",
+            "version": "2.72.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "4308217830e4ca445583a37d1bf4aff4153fa81c"
+                "reference": "0c6fd108360c562f6e4fd1dedb8233b423e91c83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4308217830e4ca445583a37d1bf4aff4153fa81c",
-                "reference": "4308217830e4ca445583a37d1bf4aff4153fa81c",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/0c6fd108360c562f6e4fd1dedb8233b423e91c83",
+                "reference": "0c6fd108360c562f6e4fd1dedb8233b423e91c83",
                 "shasum": ""
             },
             "require": {
+                "carbonphp/carbon-doctrine-types": "*",
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
                 "psr/clock": "^1.0",
@@ -569,8 +646,8 @@
                 "psr/clock-implementation": "1.0"
             },
             "require-dev": {
-                "doctrine/dbal": "^2.0 || ^3.1.4",
-                "doctrine/orm": "^2.7",
+                "doctrine/dbal": "^2.0 || ^3.1.4 || ^4.0",
+                "doctrine/orm": "^2.7 || ^3.0",
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "kylekatarnls/multi-tester": "^2.0",
                 "ondrejmirtes/better-reflection": "*",
@@ -647,7 +724,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-03T09:00:52+00:00"
+            "time": "2024-01-25T10:35:09+00:00"
         },
         {
             "name": "psr/clock",
@@ -751,6 +828,56 @@
             "time": "2021-11-05T16:47:00+00:00"
         },
         {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
+        },
+        {
             "name": "psr/simple-cache",
             "version": "3.0.0",
             "source": {
@@ -803,16 +930,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "42292d99c55abe617799667f454222c54c60e229"
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
-                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
                 "shasum": ""
             },
             "require": {
@@ -826,9 +953,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -866,7 +990,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -882,20 +1006,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-28T09:04:16+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.28.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
-                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
                 "shasum": ""
             },
             "require": {
@@ -903,9 +1027,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
@@ -949,7 +1070,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -965,7 +1086,83 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/c565ad1e63f30e7477fc40738343c62b40bc672d",
+                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/translation",
@@ -1417,7 +1614,7 @@
             "version": "v3.1.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:leroy-merlin-br/php-coding-standard.git",
+                "url": "https://github.com/leroy-merlin-br/php-coding-standard.git",
                 "reference": "7c9cc6c20d89a5e8029e4cce5661a0434adcc4e1"
             },
             "dist": {
@@ -1457,20 +1654,24 @@
                 "standard",
                 "style"
             ],
+            "support": {
+                "issues": "https://github.com/leroy-merlin-br/php-coding-standard/issues",
+                "source": "https://github.com/leroy-merlin-br/php-coding-standard/tree/v3.1.0"
+            },
             "time": "2022-04-29T20:29:50+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "1.6.6",
+            "version": "1.6.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "b8e0bb7d8c604046539c1115994632c74dcb361e"
+                "reference": "81a161d0b135df89951abd52296adf97deb0723d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/b8e0bb7d8c604046539c1115994632c74dcb361e",
-                "reference": "b8e0bb7d8c604046539c1115994632c74dcb361e",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/81a161d0b135df89951abd52296adf97deb0723d",
+                "reference": "81a161d0b135df89951abd52296adf97deb0723d",
                 "shasum": ""
             },
             "require": {
@@ -1482,10 +1683,8 @@
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.6.10",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "symplify/easy-coding-standard": "^11.5.0",
-                "vimeo/psalm": "^4.30"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
             "autoload": {
@@ -1542,7 +1741,7 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2023-08-09T00:03:52+00:00"
+            "time": "2024-03-21T18:34:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1605,25 +1804,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.17.1",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -1631,7 +1832,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1655,26 +1856,27 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
             },
-            "time": "2023-08-13T19:53:39+00:00"
+            "time": "2024-03-05T20:51:40+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -1715,9 +1917,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -1772,16 +1980,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.23.1",
+            "version": "1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26"
+                "reference": "cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/846ae76eef31c6d7790fac9bc399ecee45160b26",
-                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb",
+                "reference": "cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb",
                 "shasum": ""
             },
             "require": {
@@ -1813,29 +2021,29 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.23.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.28.0"
             },
-            "time": "2023-08-03T16:32:59+00:00"
+            "time": "2024-04-03T18:51:33+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.27",
+            "version": "9.2.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1"
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b0a88255cb70d52653d80c890bd7f38740ea50d1",
-                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -1885,7 +2093,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.27"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
             },
             "funding": [
                 {
@@ -1893,7 +2101,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-26T13:44:30+00:00"
+            "time": "2024-03-02T06:37:42+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2138,16 +2346,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.11",
+            "version": "9.6.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "810500e92855eba8a7a5319ae913be2da6f957b0"
+                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/810500e92855eba8a7a5319ae913be2da6f957b0",
-                "reference": "810500e92855eba8a7a5319ae913be2da6f957b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
                 "shasum": ""
             },
             "require": {
@@ -2162,7 +2370,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-code-coverage": "^9.2.28",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -2221,7 +2429,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
             },
             "funding": [
                 {
@@ -2237,20 +2445,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-19T07:10:56+00:00"
+            "time": "2024-04-05T04:35:58+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -2285,7 +2493,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -2293,7 +2501,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -2482,20 +2690,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -2527,7 +2735,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -2535,20 +2743,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -2593,7 +2801,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2601,7 +2809,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -2668,16 +2876,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
@@ -2733,7 +2941,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
             },
             "funding": [
                 {
@@ -2741,20 +2949,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
@@ -2797,7 +3005,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
             },
             "funding": [
                 {
@@ -2805,24 +3013,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-02T09:26:13+00:00"
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -2854,7 +3062,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -2862,7 +3070,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -3041,16 +3249,16 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -3062,7 +3270,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3083,8 +3291,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -3092,7 +3299,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
@@ -3266,16 +3473,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/267a4405fff1d9c847134db3a3c92f1ab7f77909",
+                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909",
                 "shasum": ""
             },
             "require": {
@@ -3285,11 +3492,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -3304,35 +3511,58 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-03-31T21:03:09+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -3361,7 +3591,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -3369,7 +3599,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],
@@ -3379,8 +3609,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.0",
-        "ext-mongodb": "^1.15.0"
+        "ext-mongodb": "^1.17.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - DB_HOST=db
 
   db:
-    image: mongo:5.0
+    image: mongo:6.0
     command: mongod --wiredTigerCacheSizeGB 0.25
     deploy:
       resources:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq \
     zlib1g-dev libicu-dev \
     && apt-get clean
 
-RUN pecl install xdebug-3.2.1 mongodb \
+RUN pecl install xdebug-3.2.1 mongodb-1.17.3 \
   && docker-php-ext-enable \
     mongodb xdebug \
   && docker-php-ext-configure  \

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -36,6 +36,7 @@ class Connection
         private array $options = [],
         private array $driverOptions = []
     ) {
+        $this->findDefaultDatabase($server);
     }
 
     /**
@@ -46,8 +47,6 @@ class Connection
         if (!$this->client) {
             // This will make the Mongo Driver return documents as arrays instead of objects
             $this->driverOptions['typeMap'] = ['array' => 'array'];
-
-            $this->findDefaultDatabase($this->server);
 
             $this->client = new Client(
                 $this->server,

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mongolid\Connection;
 
 use MongoDB\Client;
@@ -10,32 +13,13 @@ class Connection
 {
     /**
      * The default database where mongolid will store the documents.
-     *
-     * @var string
      */
-    public $defaultDatabase = 'mongolid';
+    public string $defaultDatabase = 'mongolid';
 
     /**
      * MongoDB Client object that represents this connection.
-     *
-     * @var Client
      */
-    protected $client;
-
-    /**
-     * @var string
-     */
-    private $server;
-
-    /**
-     * @var array
-     */
-    private $options;
-
-    /**
-     * @var array
-     */
-    private $driverOptions;
+    protected ?Client $client = null;
 
     /**
      * Constructs a new Mongolid connection. It uses the same constructor
@@ -48,13 +32,10 @@ class Connection
      * @param array  $driverOptions the mongodb driver options when opening a connection
      */
     public function __construct(
-        string $server = 'mongodb://localhost:27017',
-        array $options = [],
-        array $driverOptions = []
+        private string $server = 'mongodb://localhost:27017',
+        private array $options = [],
+        private array $driverOptions = []
     ) {
-        $this->server = $server;
-        $this->options = $options;
-        $this->driverOptions = $driverOptions;
     }
 
     /**
@@ -68,7 +49,11 @@ class Connection
 
             $this->findDefaultDatabase($this->server);
 
-            $this->client = new Client($this->server, $this->options, $this->driverOptions);
+            $this->client = new Client(
+                $this->server,
+                $this->options,
+                $this->driverOptions
+            );
         }
 
         return $this->client;
@@ -76,10 +61,8 @@ class Connection
 
     /**
      * Find and stores the default database in the connection string.
-     *
-     * @param string $connectionString mongoDB connection string
      */
-    protected function findDefaultDatabase(string $connectionString)
+    protected function findDefaultDatabase(string $connectionString): void
     {
         preg_match('/\S+\/(\w*)/', $connectionString, $matches);
 

--- a/src/Connection/Manager.php
+++ b/src/Connection/Manager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mongolid\Connection;
 
 use Illuminate\Container\Container as IlluminateContainer;
@@ -22,24 +25,11 @@ use Mongolid\Util\CacheComponentInterface;
  */
 class Manager
 {
-    /**
-     * Container being used by Mongolid.
-     *
-     * @var \Illuminate\Contracts\Container\Container
-     */
-    public $container;
+    public ?IlluminateContainer $container = null;
 
-    /**
-     * Mongolid connection object.
-     *
-     * @var Connection
-     */
-    protected $connection;
+    protected ?Connection $connection = null;
 
-    /**
-     * @var CacheComponent
-     */
-    protected $cacheComponent;
+    protected ?CacheComponent $cacheComponent = null;
 
     /**
      * Main entry point to opening a connection and start using Mongolid in
@@ -73,7 +63,7 @@ class Manager
      *
      * @param EventTriggerInterface $eventTrigger external event trigger
      */
-    public function setEventTrigger(EventTriggerInterface $eventTrigger)
+    public function setEventTrigger(EventTriggerInterface $eventTrigger): void
     {
         $this->init();
         $eventService = new EventTriggerService();
@@ -85,7 +75,7 @@ class Manager
     /**
      * Initializes the Mongolid manager.
      */
-    protected function init()
+    protected function init(): void
     {
         if ($this->container) {
             return;
@@ -93,7 +83,10 @@ class Manager
 
         $this->container = new IlluminateContainer();
         $this->cacheComponent = new CacheComponent();
-        $this->container->instance(CacheComponentInterface::class, $this->cacheComponent);
+        $this->container->instance(
+            CacheComponentInterface::class,
+            $this->cacheComponent
+        );
 
         Container::setContainer($this->container);
     }

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -1,42 +1,33 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mongolid\Container;
 
 use Illuminate\Contracts\Container\Container as IlluminateContainer;
 
 /**
- * This class is a simple Facade for a Illuminate\Container\Container
+ * This class is a simple Facade for an Illuminate\Container\Container
  * in order to use the Container as IOC at all classes.
  *
  * @mixin \Illuminate\Container\Container
  */
 class Container
 {
-    /**
-     * Illuminate instance.
-     *
-     * @var IlluminateContainer
-     */
-    protected static $container;
+    protected static ?IlluminateContainer $container = null;
 
     /**
      * Setter for static::$container.
-     *
-     * @param IlluminateContainer $container the IoC container that will be used by mongolid
      */
-    public static function setContainer(IlluminateContainer $container)
+    public static function setContainer(IlluminateContainer $container): void
     {
         static::$container = $container;
     }
 
     /**
      * Handle dynamic, static calls to the object.
-     *
-     * @param string $method method that is being called
-     * @param array  $args   method arguments
-     *
-     * @return mixed
      */
-    public static function __callStatic(string $method, array $args)
+    public static function __callStatic(string $method, array $args): mixed
     {
         $instance = static::$container;
 

--- a/src/Cursor/CacheableCursor.php
+++ b/src/Cursor/CacheableCursor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Cursor;
 
 use Iterator;

--- a/src/Cursor/CacheableCursor.php
+++ b/src/Cursor/CacheableCursor.php
@@ -17,49 +17,30 @@ use Mongolid\Util\CacheComponentInterface;
 class CacheableCursor extends Cursor
 {
     /**
-     * The documents that were retrieved from the database in a serializable way.
-     *
-     * @var array
+     * Limits the amount of documents that will be cached for performance reasons.
      */
-    protected $documents;
+    public const DOCUMENT_LIMIT = 100;
+
+    /**
+     * The documents that were retrieved from the database in a serializable way.
+     */
+    protected ?Iterator $documents = null;
 
     /**
      * Limit of the query. It is stored because when caching the documents
      * the DOCUMENT_LIMIT const will be used.
-     *
-     * @var int
      */
-    protected $originalLimit;
+    protected int $originalLimit = 0;
 
     /**
-     * Means that the CacheableCursor is wapping the original cursor and not
+     * Means that the CacheableCursor is wrapping the original cursor and not
      * reading from Cache anymore.
-     *
-     * @var bool
      */
-    protected $ignoreCache = false;
-
-    /**
-     * Limits the amount of documents that will be cached for performance reasons.
-     */
-    const DOCUMENT_LIMIT = 100;
-
-    /**
-     * Serializes this object. Drops the unserializable DriverCursor. In order
-     * to make the CacheableCursor object serializable.
-     *
-     * @return string serialized object
-     */
-    public function __serialize(): array
-    {
-        $this->documents = $this->cursor = null;
-
-        return parent::__serialize();
-    }
+    protected bool $ignoreCache = false;
 
     /**
      * Actually returns a Traversable object with the DriverCursor within.
-     * If it does not exists yet, create it using the $collection, $command and
+     * If it does not exist yet, create it using the $collection, $command and
      * $params given.
      *
      * The difference between the CacheableCursor and the normal Cursor is that
@@ -84,7 +65,7 @@ class CacheableCursor extends Cursor
 
         try {
             $cachedDocuments = $cacheComponent->get($cacheKey, null);
-        } catch (ErrorException $error) {
+        } catch (ErrorException) {
             $cachedDocuments = [];
         }
 
@@ -96,18 +77,18 @@ class CacheableCursor extends Cursor
         $this->storeOriginalLimit();
 
         // Stores the documents within the object and cache then for later use
-        $this->documents = [];
+        $documents = [];
         foreach (parent::getCursor() as $document) {
-            $this->documents[] = $document;
+            $documents[] = $document;
         }
 
-        $cacheComponent->put($cacheKey, $this->documents, 36);
+        $cacheComponent->put($cacheKey, $documents, 36);
 
         // Drops the unserializable DriverCursor.
         $this->cursor = null;
 
         // Return the documents iterator
-        return $this->documents = new ArrayIterator($this->documents);
+        return $this->documents = new ArrayIterator($documents);
     }
 
     /**
@@ -128,7 +109,7 @@ class CacheableCursor extends Cursor
     /**
      * Stores the original "limit" clause of the query.
      */
-    protected function storeOriginalLimit()
+    protected function storeOriginalLimit(): void
     {
         if (isset($this->params[1]['limit'])) {
             $this->originalLimit = $this->params[1]['limit'];
@@ -141,12 +122,10 @@ class CacheableCursor extends Cursor
 
     /**
      * Gets the limit clause of the query if any.
-     *
-     * @return mixed Int or null
      */
-    protected function getLimit()
+    protected function getLimit(): int
     {
-        return $this->originalLimit ?: ($this->params[1]['limit'] ?? null);
+        return $this->originalLimit ?: ($this->params[1]['limit'] ?? 0);
     }
 
     /**
@@ -170,5 +149,16 @@ class CacheableCursor extends Cursor
         $this->ignoreCache = true;
 
         return $this->getOriginalCursor();
+    }
+
+    /**
+     * Serializes this object. Drops the unserializable DriverCursor. In order
+     * to make the CacheableCursor object serializable.
+     */
+    public function __serialize(): array
+    {
+        $this->documents = $this->cursor = null;
+
+        return parent::__serialize();
     }
 }

--- a/src/Cursor/Cursor.php
+++ b/src/Cursor/Cursor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Cursor;
 
 use Iterator;

--- a/src/Cursor/Cursor.php
+++ b/src/Cursor/Cursor.php
@@ -1,16 +1,15 @@
 <?php
+
 namespace Mongolid\Cursor;
 
 use Iterator;
 use LogicException as BaseLogicException;
 use MongoDB\Collection;
-use MongoDB\Driver\Cursor as DriverCursor;
 use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Model\CachingIterator;
 use Mongolid\Connection\Connection;
 use Mongolid\Container\Container;
-use Serializable;
 
 /**
  * This class wraps the query execution and the actual creation of the driver cursor.
@@ -21,37 +20,16 @@ use Serializable;
 class Cursor implements CursorInterface
 {
     /**
-     * @var Collection
-     */
-    protected $collection;
-
-    /**
-     * The command that is being called in the $collection.
-     *
-     * @var string
-     */
-    protected $command;
-
-    /**
-     * The parameters of the $command.
-     *
-     * @var array
-     */
-    protected $params;
-
-    /**
      * The MongoDB cursor used to interact with db.
      *
-     * @var DriverCursor
      */
-    protected $cursor = null;
+    protected ?Iterator $cursor = null;
 
     /**
      * Iterator position (to be used with foreach).
      *
-     * @var int
      */
-    protected $position = 0;
+    protected int $position = 0;
 
     /**
      * @param Collection $collection the raw collection object that will be used to retrieve the documents
@@ -59,14 +37,10 @@ class Cursor implements CursorInterface
      * @param array      $params     the parameters of the $command
      */
     public function __construct(
-        Collection $collection,
-        string $command,
-        array $params
+        protected Collection $collection,
+        protected string $command,
+        protected array $params
     ) {
-        $this->cursor = null;
-        $this->collection = $collection;
-        $this->command = $command;
-        $this->params = $params;
     }
 
     /**
@@ -76,7 +50,7 @@ class Cursor implements CursorInterface
      *
      * @return static
      */
-    public function limit(int $amount): CursorInterface
+    public function limit(int $amount): static
     {
         $this->params[1]['limit'] = $amount;
 
@@ -92,7 +66,7 @@ class Cursor implements CursorInterface
      *
      * @return static
      */
-    public function sort(array $fields): CursorInterface
+    public function sort(array $fields): static
     {
         $this->params[1]['sort'] = $fields;
 
@@ -106,7 +80,7 @@ class Cursor implements CursorInterface
      *
      * @return static
      */
-    public function skip(int $amount): CursorInterface
+    public function skip(int $amount): static
     {
         $this->params[1]['skip'] = $amount;
 
@@ -118,10 +92,8 @@ class Cursor implements CursorInterface
      * This method should be called before the cursor was started.
      *
      * @param bool $flag toggle timeout on or off
-     *
-     * @return static
      */
-    public function disableTimeout(bool $flag = true)
+    public function disableTimeout(bool $flag = true): static
     {
         $this->params[1]['noCursorTimeout'] = $flag;
 
@@ -139,7 +111,7 @@ class Cursor implements CursorInterface
      *
      * @return $this
      */
-    public function setReadPreference(int $mode)
+    public function setReadPreference(int $mode): static
     {
         $this->params[1]['readPreference'] = new ReadPreference($mode);
 
@@ -153,7 +125,7 @@ class Cursor implements CursorInterface
      */
     public function count(): int
     {
-        return $this->collection->count(...$this->params);
+        return $this->collection->countDocuments(...$this->params);
     }
 
     /**
@@ -163,7 +135,7 @@ class Cursor implements CursorInterface
     {
         try {
             $this->getCursor()->rewind();
-        } catch (LogicException | BaseLogicException $e) {
+        } catch (LogicException | BaseLogicException) {
             $this->fresh();
             $this->getCursor();
         }
@@ -197,7 +169,7 @@ class Cursor implements CursorInterface
      * through it again. A new request to the database will be made in the next
      * iteration.
      */
-    public function fresh()
+    public function fresh(): void
     {
         $this->cursor = null;
     }
@@ -229,8 +201,6 @@ class Cursor implements CursorInterface
 
     /**
      * Convert the cursor instance to an array of Objects.
-     *
-     * @return array
      */
     public function all(): array
     {
@@ -243,8 +213,6 @@ class Cursor implements CursorInterface
 
     /**
      * Convert the cursor instance to a full associative array.
-     *
-     * @return array
      */
     public function toArray(): array
     {
@@ -256,9 +224,23 @@ class Cursor implements CursorInterface
     }
 
     /**
+     * Actually returns a Traversable object with the DriverCursor within.
+     * If it does not exist yet, create it using the $collection, $command and
+     * $params given.
+     */
+    protected function getCursor(): Iterator
+    {
+        if (!$this->cursor) {
+            $driverCursor = $this->collection->{$this->command}(...$this->params);
+            $this->cursor = new CachingIterator($driverCursor);
+        }
+
+        return $this->cursor;
+    }
+
+    /**
      * Serializes this object storing the collection name instead of the actual
      * MongoDb\Collection (which is unserializable).
-     *
      */
     public function __serialize(): array
     {
@@ -272,33 +254,22 @@ class Cursor implements CursorInterface
     /**
      * Unserializes this object. Re-creating the database connection.
      *
-     * @param mixed $serialized serialized cursor
+     * @param array $serialized serialized cursor
      */
-    public function __unserialize($attributes): void
+    public function __unserialize(array $attributes): void
     {
         $connection = Container::make(Connection::class);
         $db = $connection->defaultDatabase;
         $collectionObject = $connection->getClient()->$db->{$attributes['collection']};
 
         foreach ($attributes as $key => $value) {
+            if ('collection' === $key) {
+                continue;
+            }
+
             $this->$key = $value;
         }
 
         $this->collection = $collectionObject;
-    }
-
-    /**
-     * Actually returns a Traversable object with the DriverCursor within.
-     * If it does not exists yet, create it using the $collection, $command and
-     * $params given.
-     */
-    protected function getCursor(): Iterator
-    {
-        if (!$this->cursor) {
-            $driverCursor = $this->collection->{$this->command}(...$this->params);
-            $this->cursor = new CachingIterator($driverCursor);
-        }
-
-        return $this->cursor;
     }
 }

--- a/src/Cursor/CursorFactory.php
+++ b/src/Cursor/CursorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Cursor;
 
 use MongoDB\Collection;

--- a/src/Cursor/CursorFactory.php
+++ b/src/Cursor/CursorFactory.php
@@ -18,8 +18,6 @@ class CursorFactory
      * @param string     $command      the command that is being called in the $collection
      * @param array      $params       the parameters of the $command
      * @param bool       $cacheable    retrieves a CacheableCursor instead
-     *
-     * @return Cursor
      */
     public function createCursor(
         Schema $entitySchema,
@@ -28,7 +26,9 @@ class CursorFactory
         array $params,
         bool $cacheable = false
     ): SchemaCursor {
-        $cursorClass = $cacheable ? SchemaCacheableCursor::class : SchemaCursor::class;
+        $cursorClass = $cacheable
+            ? SchemaCacheableCursor::class
+            : SchemaCursor::class;
 
         return new $cursorClass($entitySchema, $collection, $command, $params);
     }
@@ -38,10 +38,8 @@ class CursorFactory
      *
      * @param string $entityClass class of the objects that will be retrieved by the cursor
      * @param array  $items       the items array
-     *
-     * @return CursorInterface
      */
-    public function createEmbeddedCursor($entityClass, array $items): CursorInterface
+    public function createEmbeddedCursor(string $entityClass, array $items): CursorInterface
     {
         return new SchemaEmbeddedCursor($entityClass, $items);
     }

--- a/src/Cursor/CursorInterface.php
+++ b/src/Cursor/CursorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Cursor;
 
 use Countable;
@@ -14,10 +15,8 @@ interface CursorInterface extends Countable, Iterator, Arrayable
      * Limits the number of results returned.
      *
      * @param int $amount the number of results to return
-     *
-     * @return static
      */
-    public function limit(int $amount): CursorInterface;
+    public function limit(int $amount): static;
 
     /**
      * Sorts the results by given fields.
@@ -25,38 +24,28 @@ interface CursorInterface extends Countable, Iterator, Arrayable
      * @param array $fields An array of fields by which to sort.
      *                      Each element in the array has as key the field name,
      *                      and as value either 1 for ascending sort, or -1 for descending sort.
-     *
-     * @return static
      */
-    public function sort(array $fields): CursorInterface;
+    public function sort(array $fields): static;
 
     /**
      * Skips a number of results.
      *
      * @param int $amount the number of results to skip
-     *
-     * @return static
      */
-    public function skip(int $amount): CursorInterface;
+    public function skip(int $amount): static;
 
     /**
      * Returns the first element of the cursor.
-     *
-     * @return mixed
      */
-    public function first();
+    public function first(): mixed;
 
     /**
      * Convert the cursor instance to an array of Items.
-     *
-     * @return array
      */
     public function all(): array;
 
     /**
      * Return the raw cursor items.
-     *
-     * @return array
      */
     public function toArray(): array;
 }

--- a/src/Cursor/EmbeddedCursor.php
+++ b/src/Cursor/EmbeddedCursor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Cursor;
 
 /**
@@ -10,25 +11,16 @@ namespace Mongolid\Cursor;
 class EmbeddedCursor implements CursorInterface
 {
     /**
-     * The actual array of embedded documents.
-     *
-     * @var array
-     */
-    protected $items = [];
-
-    /**
      * Iterator position (to be used with foreach).
-     *
-     * @var int
      */
-    private $position = 0;
+    private int $position = 0;
 
-    /**
-     * @param array $items
-     */
-    public function __construct(array $items)
-    {
-        $this->items = $items;
+    public function __construct(
+        /**
+         * The actual array of embedded documents.
+         */
+        protected array $items
+    ) {
     }
 
     /**
@@ -38,7 +30,7 @@ class EmbeddedCursor implements CursorInterface
      *
      * @return EmbeddedCursor returns this cursor
      */
-    public function limit(int $amount): CursorInterface
+    public function limit(int $amount): static
     {
         $this->items = array_slice($this->items, 0, $amount);
 
@@ -54,14 +46,14 @@ class EmbeddedCursor implements CursorInterface
      *
      * @return EmbeddedCursor returns this cursor
      */
-    public function sort(array $fields): CursorInterface
+    public function sort(array $fields): static
     {
         foreach (array_reverse($fields) as $key => $direction) {
             // Uses usort with a function that will access the $key and sort in
             // the $direction. It mimics how MongoDB does sorting internally.
             usort(
                 $this->items,
-                function ($a, $b) use ($key, $direction) {
+                function ($a, $b) use ($key, $direction): int {
                     $a = is_object($a)
                         ? ($a->$key ?? null)
                         : ($a[$key] ?? null);
@@ -82,10 +74,8 @@ class EmbeddedCursor implements CursorInterface
      * Skips a number of results.
      *
      * @param int $amount the number of results to skip
-     *
-     * @return EmbeddedCursor returns this cursor
      */
-    public function skip(int $amount): CursorInterface
+    public function skip(int $amount): static
     {
         $this->items = array_slice($this->items, $amount);
 
@@ -113,8 +103,6 @@ class EmbeddedCursor implements CursorInterface
     /**
      * Iterator interface current. Return a model object
      * with cursor document. (used in foreach).
-     *
-     * @return mixed
      */
     public function current(): mixed
     {

--- a/src/Cursor/EmbeddedCursor.php
+++ b/src/Cursor/EmbeddedCursor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Cursor;
 
 /**

--- a/src/Cursor/SchemaCacheableCursor.php
+++ b/src/Cursor/SchemaCacheableCursor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Cursor;
 
 use Iterator;

--- a/src/Cursor/SchemaCursor.php
+++ b/src/Cursor/SchemaCursor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Cursor;
 
 use Iterator;

--- a/src/Cursor/SchemaEmbeddedCursor.php
+++ b/src/Cursor/SchemaEmbeddedCursor.php
@@ -17,44 +17,29 @@ use Mongolid\Schema\Schema;
 class SchemaEmbeddedCursor implements CursorInterface
 {
     /**
-     * Entity class that will be returned while iterating.
-     *
-     * @var string
-     */
-    public $entityClass;
-
-    /**
-     * The actual array of embedded documents.
-     *
-     * @var array
-     */
-    protected $items = [];
-
-    /**
      * Iterator position (to be used with foreach).
-     *
-     * @var int
      */
-    private $position = 0;
+    private int $position = 0;
 
     /**
      * @param string $entityClass class of the objects that will be retrieved by the cursor
      * @param array  $items       the items array
      */
-    public function __construct($entityClass, array $items)
-    {
-        $this->items = $items;
-        $this->entityClass = $entityClass;
+    public function __construct(
+        /**
+         * Entity class that will be returned while iterating.
+         */
+        public string $entityClass,
+        protected array $items
+    ) {
     }
 
     /**
      * Limits the number of results returned.
      *
      * @param int $amount the number of results to return
-     *
-     * @return EmbeddedCursor returns this cursor
      */
-    public function limit(int $amount): CursorInterface
+    public function limit(int $amount): static
     {
         $this->items = array_slice($this->items, 0, $amount);
 
@@ -67,17 +52,15 @@ class SchemaEmbeddedCursor implements CursorInterface
      * @param array $fields An array of fields by which to sort.
      *                      Each element in the array has as key the field name,
      *                      and as value either 1 for ascending sort, or -1 for descending sort.
-     *
-     * @return EmbeddedCursor returns this cursor
      */
-    public function sort(array $fields): CursorInterface
+    public function sort(array $fields): static
     {
         foreach (array_reverse($fields) as $key => $direction) {
             // Uses usort with a function that will access the $key and sort in
             // the $direction. It mimics how the mongodb does sorting internally.
             usort(
                 $this->items,
-                function ($a, $b) use ($key, $direction) {
+                function ($a, $b) use ($key, $direction): int {
                     $a = is_object($a)
                         ? ($a->$key ?? null)
                         : ($a[$key] ?? null);
@@ -98,10 +81,8 @@ class SchemaEmbeddedCursor implements CursorInterface
      * Skips a number of results.
      *
      * @param int $amount the number of results to skip
-     *
-     * @return EmbeddedCursor returns this cursor
      */
-    public function skip(int $amount): CursorInterface
+    public function skip(int $amount): static
     {
         $this->items = array_slice($this->items, $amount);
 
@@ -110,8 +91,6 @@ class SchemaEmbeddedCursor implements CursorInterface
 
     /**
      * Counts the number of results for this cursor.
-     *
-     * returns the number of documents returned by this cursor's query
      */
     public function count(): int
     {
@@ -143,29 +122,12 @@ class SchemaEmbeddedCursor implements CursorInterface
         }
 
         $schema = $this->getSchemaForEntity();
-        $entityAssembler = Container::make(EntityAssembler::class, compact('schema'));
+        $entityAssembler = Container::make(
+            EntityAssembler::class,
+            compact('schema')
+        );
 
         return $entityAssembler->assemble($document, $schema);
-    }
-
-    /**
-     * Retrieve a schema based on Entity Class.
-     *
-     * @return Schema
-     */
-    protected function getSchemaForEntity(): Schema
-    {
-        if ($this->entityClass instanceof Schema) {
-            return $this->entityClass;
-        }
-
-        $model = new $this->entityClass();
-
-        if ($model instanceof LegacyRecord) {
-            return $model->getSchema();
-        }
-
-        return new DynamicSchema();
     }
 
     /**
@@ -220,5 +182,23 @@ class SchemaEmbeddedCursor implements CursorInterface
     public function toArray(): array
     {
         return $this->items;
+    }
+
+    /**
+     * Retrieve a schema based on Entity Class.
+     */
+    protected function getSchemaForEntity(): Schema
+    {
+        if ($this->entityClass instanceof Schema) {
+            return $this->entityClass;
+        }
+
+        $model = new $this->entityClass();
+
+        if ($model instanceof LegacyRecord) {
+            return $model->getSchema();
+        }
+
+        return new DynamicSchema();
     }
 }

--- a/src/Cursor/SchemaEmbeddedCursor.php
+++ b/src/Cursor/SchemaEmbeddedCursor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Cursor;
 
 use Mongolid\Container\Container;

--- a/src/Event/EventTriggerInterface.php
+++ b/src/Event/EventTriggerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Event;
 
 /**
@@ -19,5 +20,5 @@ interface EventTriggerInterface
      *
      * @return mixed Event handler return. The importance of this return is determined by $halt
      */
-    public function fire(string $event, $payload, bool $halt);
+    public function fire(string $event, mixed $payload, bool $halt): mixed;
 }

--- a/src/Event/EventTriggerService.php
+++ b/src/Event/EventTriggerService.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mongolid\Event;
 
 /**
@@ -8,18 +11,16 @@ class EventTriggerService
 {
     /**
      * The one who are going to actually trigger the events to the rest of the application.
-     *
-     * @var EventTriggerInterface
      */
-    protected $dispatcher;
+    protected ?EventTriggerInterface $dispatcher = null;
 
     /**
-     * Registers a object that will have the responsibility of firing events to
+     * Registers an object that will have the responsibility of firing events to
      * the rest of the application.
      *
      * @param EventTriggerInterface $builder event trigger object
      */
-    public function registerEventDispatcher(EventTriggerInterface $builder)
+    public function registerEventDispatcher(EventTriggerInterface $builder): void
     {
         $this->dispatcher = $builder;
     }
@@ -36,7 +37,7 @@ class EventTriggerService
      *
      * @return mixed Event handler return. The importance of this return is determined by $halt
      */
-    public function fire(string $event, $payload, bool $halt = false)
+    public function fire(string $event, mixed $payload, bool $halt = false): mixed
     {
         if ($this->dispatcher) {
             return $this->dispatcher->fire($event, $payload, $halt);

--- a/src/Schema/DynamicSchema.php
+++ b/src/Schema/DynamicSchema.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Schema;
 
 /**
  * The DynamicSchema will accept additional fields that are not specified in
- * the $schema property. This is useful if you does not have a clear idea
+ * the $schema property. This is useful if you do not have a clear idea
  * of how the document will look like.
  */
 class DynamicSchema extends Schema
@@ -12,5 +14,5 @@ class DynamicSchema extends Schema
     /**
      * {@inheritdoc}
      */
-    public $dynamic = true;
+    public bool $dynamic = true;
 }

--- a/src/Schema/HasSchemaInterface.php
+++ b/src/Schema/HasSchemaInterface.php
@@ -6,8 +6,6 @@ interface HasSchemaInterface
 {
     /**
      * Returns a Schema object that describes an Entity in MongoDB.
-     *
-     * @return Schema
      */
     public function getSchema(): Schema;
 }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Schema;
 
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 use Mongolid\Container\Container;
-use Mongolid\Container\Ioc;
 use Mongolid\Util\ObjectIdUtils;
 use Mongolid\Util\SequenceService;
 
@@ -18,24 +19,20 @@ abstract class Schema
     /**
      * The $dynamic property tells if the schema will accept additional fields
      * that are not specified in the $fields property. This is useful if you
-     * does not have a strict document format or if you want to take full
+     * do not have a strict document format or if you want to take full
      * advantage of the "schemaless" nature of MongoDB.
-     *
-     * @var bool
      */
-    public $dynamic = false;
+    public bool $dynamic = false;
 
     /**
      * Name of the collection where this kind of document is going to be saved
      * or retrieved from.
-     *
-     * @var string
      */
-    public $collection = null;
+    public ?string $collection = null;
 
     /**
-     * Tells how a document should look like. If an scalar type is used, it will
-     * perform a cast into the value. Otherwise the schema will use the type as
+     * Tells how a document should look like. If a scalar type is used, it will
+     * perform a cast into the value. Otherwise, the schema will use the type as
      * the name of the method to be called. See 'objectId' method for example.
      * The last option is to define a field as another schema by using the
      * syntax 'schema.<Class>' This represents an embedded document (or
@@ -43,8 +40,8 @@ abstract class Schema
      *
      * @var string[]
      */
-    public $fields = [
-        '_id' => 'objectId', // Means that the _id will pass trough the `objectId` method
+    public array $fields = [
+        '_id' => 'objectId', // Means that the _id will pass through the `objectId` method
         'created_at' => 'createdAtTimestamp', // Generates an automatic timestamp
         'updated_at' => 'updatedAtTimestamp',
     ];
@@ -52,27 +49,23 @@ abstract class Schema
     /**
      * Name of the class that will be used to represent a document of this
      * Schema when retrieve from the database.
-     *
-     * @var string
      */
-    public $entityClass = 'stdClass';
+    public string $entityClass = 'stdClass';
 
     /**
      * Filters any field in the $fields that has it's value specified as a
      * 'objectId'. It will wraps the $value, if any, into a ObjectId object.
      *
      * @param mixed $value value that may be converted to ObjectId
-     *
-     * @return ObjectId|mixed
      */
-    public function objectId($value = null)
+    public function objectId(mixed $value = null): mixed
     {
         if (null === $value) {
             return new ObjectId();
         }
 
         if (is_string($value) && ObjectIdUtils::isObjectId($value)) {
-            $value = new ObjectId($value);
+            return new ObjectId($value);
         }
 
         return $value;
@@ -84,10 +77,8 @@ abstract class Schema
      * the schema. The sequence generation is done by the SequenceService.
      *
      * @param int|null $value value that will be evaluated
-     *
-     * @return int
      */
-    public function sequence(int $value = null)
+    public function sequence(?int $value = null): int
     {
         if ($value) {
             return $value;
@@ -101,10 +92,8 @@ abstract class Schema
      * Prepares the field to be the datetime that the document has been created.
      *
      * @param mixed|null $value value that will be evaluated
-     *
-     * @return UTCDateTime
      */
-    public function createdAtTimestamp($value)
+    public function createdAtTimestamp(mixed $value): UTCDateTime
     {
         if ($value instanceof UTCDateTime) {
             return $value;
@@ -115,10 +104,8 @@ abstract class Schema
 
     /**
      * Prepares the field to be now.
-     *
-     * @return UTCDateTime
      */
-    public function updatedAtTimestamp()
+    public function updatedAtTimestamp(): UTCDateTime
     {
         return new UTCDateTime();
     }

--- a/src/Util/CacheComponent.php
+++ b/src/Util/CacheComponent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mongolid\Util;
 
 /**
@@ -11,39 +13,39 @@ class CacheComponent implements CacheComponentInterface
     /**
      * The array of stored values.
      *
-     * @var array
+     * @var array<string, mixed>
      */
-    protected $storage = [];
+    protected array $storage = [];
 
     /**
      * Time to live of each stored value.
      *
-     * @var array
+     * @var array<string, float>
      */
-    protected $ttl = [];
+    protected array $ttl = [];
 
     /**
      * Retrieve an item from the cache by key.
      *
      * @param string $key cache key of the item to be retrieved
-     *
-     * @return mixed
      */
-    public function get(string $key)
+    public function get(string $key): mixed
     {
         if ($this->has($key)) {
             return $this->storage[$key];
         }
+
+        return null;
     }
 
     /**
      * Store an item in the cache for a given number of minutes.
      *
-     * @param string $key cache key of the item
-     * @param mixed $value value being stored in cache
-     * @param float $minutes cache ttl
+     * @param string $key     cache key of the item
+     * @param mixed  $value   value being stored in cache
+     * @param float  $minutes cache ttl
      */
-    public function put(string $key, $value, float $minutes)
+    public function put(string $key, mixed $value, float $minutes): void
     {
         $this->storage[$key] = $value;
         $this->ttl[$key] = $this->time() + 60 * $minutes;
@@ -60,7 +62,8 @@ class CacheComponent implements CacheComponentInterface
      */
     public function has(string $key): bool
     {
-        if (array_key_exists($key, $this->ttl) &&
+        if (
+            array_key_exists($key, $this->ttl) &&
             $this->time() - $this->ttl[$key] > 0
         ) {
             unset($this->ttl[$key]);
@@ -79,7 +82,7 @@ class CacheComponent implements CacheComponentInterface
      *
      * @return int return current Unix timestamp
      */
-    protected function time()
+    protected function time(): int
     {
         return time();
     }

--- a/src/Util/CacheComponentInterface.php
+++ b/src/Util/CacheComponentInterface.php
@@ -12,10 +12,8 @@ interface CacheComponentInterface
      * Retrieve an item from the cache by key.
      *
      * @param string $key cache key of the item to be retrieved
-     *
-     * @return mixed
      */
-    public function get(string $key);
+    public function get(string $key): mixed;
 
     /**
      * Store an item in the cache for a given number of minutes.
@@ -24,7 +22,7 @@ interface CacheComponentInterface
      * @param mixed  $value   value being stored in cache
      * @param float  $minutes cache ttl
      */
-    public function put(string $key, $value, float $minutes);
+    public function put(string $key, mixed $value, float $minutes): void;
 
     /**
      * Determine if an item exists in the cache. This method will also check

--- a/src/Util/LocalDateTime.php
+++ b/src/Util/LocalDateTime.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mongolid\Util;
 
 use DateTime;

--- a/src/Util/ObjectIdUtils.php
+++ b/src/Util/ObjectIdUtils.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mongolid\Util;
 
 use MongoDB\BSON\ObjectId;
@@ -14,7 +17,7 @@ class ObjectIdUtils
      *
      * @param mixed $value string to be evaluated if it can be used as a valid ObjectId
      */
-    public static function isObjectId($value): bool
+    public static function isObjectId(mixed $value): bool
     {
         if ($value instanceof ObjectId) {
             return true;
@@ -24,6 +27,8 @@ class ObjectIdUtils
             $value = (string) $value;
         }
 
-        return is_string($value) && 24 == strlen($value) && ctype_xdigit($value);
+        return is_string($value)
+            && 24 == strlen($value)
+            && ctype_xdigit($value);
     }
 }

--- a/src/Util/SequenceService.php
+++ b/src/Util/SequenceService.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mongolid\Util;
 
 use MongoDB\Collection;
@@ -11,24 +14,16 @@ use Mongolid\Connection\Connection;
  */
 class SequenceService
 {
-    /**
-     * Sequences collection name on MongoDB. Default 'mongolid_sequences'.
-     *
-     * @var string
-     */
-    protected $collection;
-
-    /**
-     * Connection that is going to be used to interact with the database.
-     *
-     * @var Connection
-     */
-    protected $connection;
-
-    public function __construct(Connection $connection, string $collection = 'mongolid_sequences')
-    {
-        $this->connection = $connection;
-        $this->collection = $collection;
+    public function __construct(
+        /**
+         * Connection that is going to be used to interact with the database.
+         */
+        protected Connection $connection,
+        /**
+         * Sequences collection name on MongoDB. Default 'mongolid_sequences'.
+         */
+        protected string $collection = 'mongolid_sequences'
+    ) {
     }
 
     /**

--- a/tests/Unit/Connection/ConnectionTest.php
+++ b/tests/Unit/Connection/ConnectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Connection;
 
 use Mongolid\TestCase;
@@ -52,6 +53,9 @@ final class ConnectionTest extends TestCase
 
         // Assertions
         $this->assertSame($expectedParameters['uri'], (string) $client);
-        $this->assertSame($expectedParameters['typeMap'], $client->getTypeMap());
+        $this->assertSame(
+            $expectedParameters['typeMap'],
+            $client->getTypeMap()
+        );
     }
 }

--- a/tests/Unit/Connection/ManagerTest.php
+++ b/tests/Unit/Connection/ManagerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Connection;
 
 use Illuminate\Container\Container as IlluminateContainer;
@@ -33,7 +34,6 @@ final class ManagerTest extends TestCase
     public function testShouldSetEventTrigger(): void
     {
         // Set
-        $test = $this;
         $manager = new Manager();
         $container = m::mock(IlluminateContainer::class);
         $eventTrigger = m::mock(EventTriggerInterface::class);
@@ -41,15 +41,18 @@ final class ManagerTest extends TestCase
         $this->setProtected($manager, 'container', $container);
 
         // Expectations
-        $expectationCallable = function ($class, $eventService) use ($test, $eventTrigger) {
-            $test->assertSame(EventTriggerService::class, $class);
+        $expectationCallable = function ($class, $eventService) use ($eventTrigger): void {
+            $this->assertSame(EventTriggerService::class, $class);
             $dispatcher = $this->getProtected($eventService, 'dispatcher');
-            $test->assertSame($eventTrigger, $dispatcher);
+            $this->assertSame($eventTrigger, $dispatcher);
         };
 
         $container
             ->expects('instance')
-            ->with(EventTriggerService::class, m::type(EventTriggerService::class))
+            ->with(
+                EventTriggerService::class,
+                m::type(EventTriggerService::class)
+            )
             ->andReturnUsing($expectationCallable);
 
         // Actions
@@ -65,7 +68,10 @@ final class ManagerTest extends TestCase
         $this->callProtected($manager, 'init');
 
         // Assertions
-        $this->assertInstanceOf(IlluminateContainer::class, $manager->container);
+        $this->assertInstanceOf(
+            IlluminateContainer::class,
+            $manager->container
+        );
 
         // Actions
         $container = $manager->container;

--- a/tests/Unit/Container/ContainerTest.php
+++ b/tests/Unit/Container/ContainerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Container;
 
 use Illuminate\Container\Container as IlluminateContainer;
@@ -7,14 +8,6 @@ use Mongolid\TestCase;
 
 final class ContainerTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Container::expects()
-            ->flush();
-
-        parent::tearDown();
-    }
-
     public function testShouldCallMethodsProperlyWithNoArguments(): void
     {
         // Set
@@ -45,5 +38,13 @@ final class ContainerTest extends TestCase
 
         // Actions
         Container::method(1, 2, 3);
+    }
+
+    protected function tearDown(): void
+    {
+        Container::expects()
+            ->flush();
+
+        parent::tearDown();
     }
 }

--- a/tests/Unit/Cursor/CacheableCursorTest.php
+++ b/tests/Unit/Cursor/CacheableCursorTest.php
@@ -4,6 +4,7 @@ namespace Mongolid\Cursor;
 
 use ArrayIterator;
 use ErrorException;
+use Iterator;
 use Mockery as m;
 use MongoDB\Collection;
 use Mongolid\Container\Container;
@@ -12,16 +13,12 @@ use Mongolid\TestCase;
 
 class CacheableCursorTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        parent::tearDown();
-        m::close();
-    }
-
     public function testShouldGetCursorFromPreviousIteration(): void
     {
         // Arrange
-        $documentsFromDb = new ArrayIterator([['name' => 'joe'], ['name' => 'doe']]);
+        $documentsFromDb = new ArrayIterator(
+            [['name' => 'joe'], ['name' => 'doe']]
+        );
         $cursor = $this->getCacheableCursor();
         $this->setProtected(
             $cursor,
@@ -67,7 +64,7 @@ class CacheableCursorTest extends TestCase
         $documentsFromDb = [['name' => 'joe'], ['name' => 'doe']];
         $cursor = $this->getCacheableCursor()->limit(150);
         $cacheComponent = m::mock(CacheComponentInterface::class);
-        $rawCollection = m::mock();
+        $rawCollection = m::mock(Collection::class);
         $cacheKey = 'find:collection:123';
 
         $this->setProtected(
@@ -111,7 +108,7 @@ class CacheableCursorTest extends TestCase
         $documentsFromDb = [['name' => 'joe'], ['name' => 'doe']];
         $cursor = $this->getCacheableCursor()->limit(150);
         $cacheComponent = m::mock(CacheComponentInterface::class);
-        $rawCollection = m::mock();
+        $rawCollection = m::mock(Collection::class);
 
         $this->setProtected(
             $cursor,
@@ -150,7 +147,7 @@ class CacheableCursorTest extends TestCase
         $documentsFromDb = [['name' => 'joe'], ['name' => 'doe']];
         $cursor = $this->getCacheableCursor()->limit(150);
         $cacheComponent = m::mock(CacheComponentInterface::class);
-        $rawCollection = m::mock();
+        $rawCollection = m::mock(Collection::class);
 
         $this->setProtected(
             $cursor,
@@ -175,7 +172,10 @@ class CacheableCursorTest extends TestCase
             ->never();
 
         $rawCollection->shouldReceive('find')
-            ->with([], ['skip' => CacheableCursor::DOCUMENT_LIMIT, 'limit' => 49])
+            ->with(
+                [],
+                ['skip' => CacheableCursor::DOCUMENT_LIMIT, 'limit' => 49]
+            )
             ->andReturn(new ArrayIterator($documentsFromDb));
 
         $cacheComponent->shouldReceive('put')
@@ -191,7 +191,11 @@ class CacheableCursorTest extends TestCase
     public function testShouldGenerateUniqueCacheKey(): void
     {
         // Arrange
-        $cursor = $this->getCacheableCursor(null, 'find', [['color' => 'red']]);
+        $cursor = $this->getCacheableCursor(
+            null,
+            'find',
+            [['color' => 'red']]
+        );
 
         // Act
         $cursor->shouldReceive('generateCacheKey')
@@ -212,11 +216,11 @@ class CacheableCursorTest extends TestCase
     }
 
     protected function getCacheableCursor(
-        $collection = null,
-        $command = 'find',
-        $params = [[]],
-        $driverCursor = null
-    ) {
+        ?Collection $collection = null,
+        string $command = 'find',
+        array $params = [[]],
+        ?Iterator $driverCursor = null
+    ): CacheableCursor {
         if (!$collection) {
             $collection = m::mock(Collection::class);
             $collection->shouldReceive('getNamespace')
@@ -239,4 +243,3 @@ class CacheableCursorTest extends TestCase
         return $mock;
     }
 }
-

--- a/tests/Unit/Cursor/CursorFactoryTest.php
+++ b/tests/Unit/Cursor/CursorFactoryTest.php
@@ -9,7 +9,7 @@ use Mongolid\TestCase;
 
 class CursorFactoryTest extends TestCase
 {
-    public function testShouldCreateACursor()
+    public function testShouldCreateACursor(): void
     {
         // Set
         $factory = new CursorFactory();
@@ -30,7 +30,7 @@ class CursorFactoryTest extends TestCase
         $this->assertEquals($schema, $result->entitySchema);
     }
 
-    public function testShouldCreateACacheableCursor()
+    public function testShouldCreateACacheableCursor(): void
     {
         // Set
         $factory = new CursorFactory();
@@ -52,14 +52,17 @@ class CursorFactoryTest extends TestCase
         $this->assertEquals($schema, $result->entitySchema);
     }
 
-    public function testShouldCreateAEmbeddedCursor()
+    public function testShouldCreateAEmbeddedCursor(): void
     {
         // Set
         $factory = new CursorFactory();
         $entityClass = 'MyModelClass';
 
         // Assert
-        $result = $factory->createEmbeddedCursor($entityClass, [['foo' => 'bar']]);
+        $result = $factory->createEmbeddedCursor(
+            $entityClass,
+            [['foo' => 'bar']]
+        );
 
         $this->assertInstanceOf(SchemaEmbeddedCursor::class, $result);
         $this->assertNotInstanceOf(SchemaCursor::class, $result);

--- a/tests/Unit/Cursor/EmbeddedCursorTest.php
+++ b/tests/Unit/Cursor/EmbeddedCursorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Cursor;
 
 use Mongolid\Model\AbstractModel;
@@ -112,7 +113,7 @@ final class EmbeddedCursorTest extends TestCase
         $object = new class extends AbstractModel
         {
         };
-        $class = get_class($object);
+        $class = $object::class;
         $itemA = new $class();
         $itemA->name = 'A';
 
@@ -175,7 +176,7 @@ final class EmbeddedCursorTest extends TestCase
     public function testShouldGetCurrentUsingModelClassMorphingIt(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
         $model->name = 'John';
@@ -198,7 +199,7 @@ final class EmbeddedCursorTest extends TestCase
         $object = new class extends AbstractModel
         {
         };
-        $class = get_class($object);
+        $class = $object::class;
         $modelA = new $class();
         $modelA->name = 'A';
         $modelA->syncOriginalDocumentAttributes();

--- a/tests/Unit/Cursor/SchemaCursorTest.php
+++ b/tests/Unit/Cursor/SchemaCursorTest.php
@@ -11,6 +11,7 @@ use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Database;
 use MongoDB\Driver\Exception\LogicException;
+use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadPreference;
 use Mongolid\Connection\Connection;
 use Mongolid\LegacyRecord;
@@ -21,13 +22,7 @@ use Traversable;
 
 class SchemaCursorTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        parent::tearDown();
-        m::close();
-    }
-
-    public function testShouldLimitDocumentQuantity()
+    public function testShouldLimitDocumentQuantity(): void
     {
         // Arrange
         $cursor = $this->getCursor();
@@ -40,7 +35,7 @@ class SchemaCursorTest extends TestCase
         );
     }
 
-    public function testShouldSortDocumentsOfCursor()
+    public function testShouldSortDocumentsOfCursor(): void
     {
         // Arrange
         $cursor = $this->getCursor();
@@ -53,7 +48,7 @@ class SchemaCursorTest extends TestCase
         );
     }
 
-    public function testShouldSkipDocuments()
+    public function testShouldSkipDocuments(): void
     {
         // Arrange
         $cursor = $this->getCursor();
@@ -66,7 +61,7 @@ class SchemaCursorTest extends TestCase
         );
     }
 
-    public function testShouldSetNoCursorTimeoutToTrue()
+    public function testShouldSetNoCursorTimeoutToTrue(): void
     {
         // Arrange
         $cursor = $this->getCursor();
@@ -79,27 +74,33 @@ class SchemaCursorTest extends TestCase
         );
     }
 
-    public function testShouldSetReadPreferenceParameterAccordingly()
+    public function testShouldSetReadPreferenceParameterAccordingly(): void
     {
         // Arrange
         $cursor = $this->getCursor();
         $mode = ReadPreference::RP_SECONDARY;
         $cursor->setReadPreference($mode);
-        $readPreferenceParameter = $this->getProtected($cursor, 'params')[1]['readPreference'];
+        $readPreferenceParameter = $this->getProtected(
+            $cursor,
+            'params'
+        )[1]['readPreference'];
 
         // Assert
-        $this->assertInstanceOf(ReadPreference::class, $readPreferenceParameter);
+        $this->assertInstanceOf(
+            ReadPreference::class,
+            $readPreferenceParameter
+        );
         $this->assertSame($readPreferenceParameter->getMode(), $mode);
     }
 
-    public function testShouldCountDocuments()
+    public function testShouldCountDocuments(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
         $cursor = $this->getCursor(null, $collection);
 
         // Act
-        $collection->shouldReceive('count')
+        $collection->shouldReceive('countDocuments')
             ->once()
             ->with([])
             ->andReturn(5);
@@ -108,14 +109,14 @@ class SchemaCursorTest extends TestCase
         $this->assertEquals(5, $cursor->count());
     }
 
-    public function testShouldCountDocumentsWithCountFunction()
+    public function testShouldCountDocumentsWithCountFunction(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
         $cursor = $this->getCursor(null, $collection);
 
         // Act
-        $collection->shouldReceive('count')
+        $collection->shouldReceive('countDocuments')
             ->once()
             ->with([])
             ->andReturn(5);
@@ -124,12 +125,18 @@ class SchemaCursorTest extends TestCase
         $this->assertEquals(5, count($cursor));
     }
 
-    public function testShouldRewind()
+    public function testShouldRewind(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
         $driverCursor = m::mock(IteratorIterator::class);
-        $cursor = $this->getCursor(null, $collection, 'find', [[]], $driverCursor);
+        $cursor = $this->getCursor(
+            null,
+            $collection,
+            'find',
+            [[]],
+            $driverCursor
+        );
 
         $this->setProtected($cursor, 'position', 10);
 
@@ -142,19 +149,25 @@ class SchemaCursorTest extends TestCase
         $this->assertEquals(0, $cursor->key());
     }
 
-    public function testShouldRewindACursorThatHasAlreadyBeenInitialized()
+    public function testShouldRewindACursorThatHasAlreadyBeenInitialized(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
         $driverCursor = m::mock(IteratorIterator::class);
-        $cursor = $this->getCursor(null, $collection, 'find', [[]], $driverCursor);
+        $cursor = $this->getCursor(
+            null,
+            $collection,
+            'find',
+            [[]],
+            $driverCursor
+        );
 
         $this->setProtected($cursor, 'position', 10);
 
         // Act
         $driverCursor->shouldReceive('rewind')
             ->twice()
-            ->andReturnUsing(function () use ($cursor) {
+            ->andReturnUsing(function () use ($cursor): void {
                 if ($this->getProtected($cursor, 'cursor')) {
                     throw new LogicException('Cursor already initialized', 1);
                 }
@@ -165,15 +178,21 @@ class SchemaCursorTest extends TestCase
         $this->assertEquals(0, $cursor->key());
     }
 
-    public function testShouldGetCurrentUsingLegacyRecordClasses()
+    public function testShouldGetCurrentUsingLegacyRecordClasses(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
-        $entity = new class() extends LegacyRecord {
+        $entity = new class () extends LegacyRecord {
         };
         $entity->name = 'John Doe';
         $driverCursor = new ArrayIterator([$entity]);
-        $cursor = $this->getCursor(null, $collection, 'find', [[]], $driverCursor);
+        $cursor = $this->getCursor(
+            null,
+            $collection,
+            'find',
+            [[]],
+            $driverCursor
+        );
 
         // Assert
         $entity = $cursor->current();
@@ -181,12 +200,18 @@ class SchemaCursorTest extends TestCase
         $this->assertEquals('John Doe', $entity->name);
     }
 
-    public function testShouldGetFirstWhenEmpty()
+    public function testShouldGetFirstWhenEmpty(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
         $driverCursor = m::mock(IteratorIterator::class);
-        $cursor = $this->getCursor(null, $collection, 'find', [[]], $driverCursor);
+        $cursor = $this->getCursor(
+            null,
+            $collection,
+            'find',
+            [[]],
+            $driverCursor
+        );
 
         // Act
         $driverCursor->shouldReceive('rewind')
@@ -201,7 +226,7 @@ class SchemaCursorTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testShouldRefreshTheCursor()
+    public function testShouldRefreshTheCursor(): void
     {
         // Arrange
         $driverCursor = m::mock(IteratorIterator::class);
@@ -213,7 +238,7 @@ class SchemaCursorTest extends TestCase
         $this->assertEquals(null, $cursor->key());
     }
 
-    public function testShouldImplementKeyMethodFromIterator()
+    public function testShouldImplementKeyMethodFromIterator(): void
     {
         // Arrange
         $cursor = $this->getCursor();
@@ -224,12 +249,18 @@ class SchemaCursorTest extends TestCase
         $this->assertEquals(7, $cursor->key());
     }
 
-    public function testShouldImplementNextMethodFromIterator()
+    public function testShouldImplementNextMethodFromIterator(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
         $driverCursor = m::mock(IteratorIterator::class);
-        $cursor = $this->getCursor(null, $collection, 'find', [[]], $driverCursor);
+        $cursor = $this->getCursor(
+            null,
+            $collection,
+            'find',
+            [[]],
+            $driverCursor
+        );
 
         $this->setProtected($cursor, 'position', 7);
 
@@ -242,12 +273,18 @@ class SchemaCursorTest extends TestCase
         $this->assertEquals(8, $cursor->key());
     }
 
-    public function testShouldImplementValidMethodFromIterator()
+    public function testShouldImplementValidMethodFromIterator(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
         $driverCursor = m::mock(IteratorIterator::class);
-        $cursor = $this->getCursor(null, $collection, 'find', [[]], $driverCursor);
+        $cursor = $this->getCursor(
+            null,
+            $collection,
+            'find',
+            [[]],
+            $driverCursor
+        );
 
         // Act
         $driverCursor->shouldReceive('valid')
@@ -257,11 +294,16 @@ class SchemaCursorTest extends TestCase
         $this->assertTrue($cursor->valid());
     }
 
-    public function testShouldWrapMongoDriverCursorWithIteratoriterator()
+    public function testShouldWrapMongoDriverCursorWithIteratoriterator(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
-        $cursor = $this->getCursor(null, $collection, 'find', [['bacon' => true]]);
+        $cursor = $this->getCursor(
+            null,
+            $collection,
+            'find',
+            [['bacon' => true]]
+        );
         $driverCursor = m::mock(Traversable::class);
         $driverIterator = m::mock(Iterator::class);
 
@@ -285,12 +327,18 @@ class SchemaCursorTest extends TestCase
         $this->assertInstanceOf(IteratorIterator::class, $result);
     }
 
-    public function testShouldReturnResultsToArray()
+    public function testShouldReturnResultsToArray(): void
     {
         // Arrange
         $collection = m::mock(Collection::class);
         $driverCursor = m::mock(IteratorIterator::class);
-        $cursor = $this->getCursor(null, $collection, 'find', [[]], $driverCursor);
+        $cursor = $this->getCursor(
+            null,
+            $collection,
+            'find',
+            [[]],
+            $driverCursor
+        );
 
         // Act
         $driverCursor->shouldReceive('rewind', 'valid', 'key')
@@ -318,10 +366,13 @@ class SchemaCursorTest extends TestCase
         );
     }
 
-    public function testShouldSerializeAnActiveCursor()
+    public function testShouldSerializeAnActiveCursor(): void
     {
         // Arrange
-        $connection = $this->instance(Connection::class, m::mock(Connection::class));
+        $connection = $this->instance(
+            Connection::class,
+            m::mock(Connection::class)
+        );
         $schema = new DynamicSchema();
         $client = m::mock(Client::class);
         $database = m::mock(Database::class);
@@ -359,7 +410,7 @@ class SchemaCursorTest extends TestCase
         $driverCursor = null
     ) {
         if (!$entitySchema) {
-            $entitySchema = m::mock(Schema::class.'[]');
+            $entitySchema = m::mock(Schema::class . '[]');
         }
 
         if (!$collection) {
@@ -367,11 +418,16 @@ class SchemaCursorTest extends TestCase
         }
 
         if (!$driverCursor) {
-            return new SchemaCursor($entitySchema, $collection, $command, $params);
+            return new SchemaCursor(
+                $entitySchema,
+                $collection,
+                $command,
+                $params
+            );
         }
 
         $mock = m::mock(
-            SchemaCursor::class.'[getCursor]',
+            SchemaCursor::class . '[getCursor]',
             [$entitySchema, $collection, $command, $params]
         );
 
@@ -388,24 +444,24 @@ class SchemaCursorTest extends TestCase
      * Since the MongoDB\Collection is not serializable. This method will
      * emulate an unserializable collection from mongoDb driver.
      */
-    protected function getDriverCollection()
+    protected function getDriverCollection(): Collection
     {
         /*
          * Emulates a MongoDB\Collection non serializable behavior.
          */
-        return new class() {
-            public function __serialize()
-            {
-                throw new Exception('Unable to serialize', 1);
-            }
-
-            public function __unserialize($serialized)
+        return new class () extends Collection {
+            public function __construct()
             {
             }
 
-            public function getCollectionName()
+            public function getCollectionName(): string
             {
                 return 'my_collection';
+            }
+
+            public function __serialize(): array
+            {
+                throw new Exception('Unable to serialize', 1);
             }
         };
     }

--- a/tests/Unit/Cursor/SchemaEmbeddedCursorTest.php
+++ b/tests/Unit/Cursor/SchemaEmbeddedCursorTest.php
@@ -2,19 +2,12 @@
 
 namespace Mongolid\Cursor;
 
-use Mockery as m;
 use stdClass;
 use Mongolid\TestCase;
 
 class SchemaEmbeddedCursorTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        parent::tearDown();
-        m::close();
-    }
-
-    public function testShouldLimitDocumentQuantity()
+    public function testShouldLimitDocumentQuantity(): void
     {
         // Arrange
         $items = [
@@ -38,7 +31,7 @@ class SchemaEmbeddedCursorTest extends TestCase
     /**
      * @dataProvider getDocumentsToSort
      */
-    public function testShouldSortDocuments($items, $parameters, $expected)
+    public function testShouldSortDocuments(array $items, array $parameters, array $expected): void
     {
         // Arrange
         $cursor = $this->getCursor(stdClass::class, $items);
@@ -51,7 +44,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         );
     }
 
-    public function testShouldSkipDocuments()
+    public function testShouldSkipDocuments(): void
     {
         // Arrange
         $items = [
@@ -71,7 +64,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         );
     }
 
-    public function testShouldCountDocuments()
+    public function testShouldCountDocuments(): void
     {
         // Arrange
         $items = [
@@ -85,7 +78,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertEquals(3, $cursor->count());
     }
 
-    public function testShouldCountDocumentsWithCountFunction()
+    public function testShouldCountDocumentsWithCountFunction(): void
     {
         // Arrange
         $items = [
@@ -99,7 +92,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertEquals(3, count($cursor));
     }
 
-    public function testShouldRewind()
+    public function testShouldRewind(): void
     {
         // Arrange
         $cursor = $this->getCursor();
@@ -109,7 +102,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertEquals(0, $cursor->key());
     }
 
-    public function testShouldNotGetCurrentWhenCursorIsInvalid()
+    public function testShouldNotGetCurrentWhenCursorIsInvalid(): void
     {
         // Arrange
         $items = [];
@@ -122,7 +115,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertNull($entity);
     }
 
-    public function testShouldGetCurrentUsingEntityClass()
+    public function testShouldGetCurrentUsingEntityClass(): void
     {
         // Arrange
         $object = new stdClass();
@@ -138,7 +131,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertEquals('A', $entity->name);
     }
 
-    public function testShouldGetAllInArrayFormat()
+    public function testShouldGetAllInArrayFormat(): void
     {
         // Arrange
         $items = [
@@ -155,7 +148,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertEquals($items, $result);
     }
 
-    public function testShouldImplementKeyMethodFromIterator()
+    public function testShouldImplementKeyMethodFromIterator(): void
     {
         // Arrange
         $cursor = $this->getCursor();
@@ -166,7 +159,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertEquals(7, $cursor->key());
     }
 
-    public function testShouldImplementNextMethodFromIterator()
+    public function testShouldImplementNextMethodFromIterator(): void
     {
         // Arrange
         $cursor = $this->getCursor();
@@ -178,7 +171,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertEquals(8, $cursor->key());
     }
 
-    public function testShouldImplementValidMethodFromIterator()
+    public function testShouldImplementValidMethodFromIterator(): void
     {
         // Arrange
         $items = [
@@ -194,14 +187,7 @@ class SchemaEmbeddedCursorTest extends TestCase
         $this->assertFalse($cursor->valid());
     }
 
-    protected function getCursor(
-        $entityClass = stdClass::class,
-        $items = []
-    ) {
-        return new SchemaEmbeddedCursor($entityClass, $items);
-    }
-
-    public function getDocumentsToSort()
+    public function getDocumentsToSort(): array
     {
         $age24 = (object) ['age' => 24];
 
@@ -277,5 +263,12 @@ class SchemaEmbeddedCursorTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    protected function getCursor(
+        $entityClass = stdClass::class,
+        $items = []
+    ): SchemaEmbeddedCursor {
+        return new SchemaEmbeddedCursor($entityClass, $items);
     }
 }

--- a/tests/Unit/Event/EventTriggerServiceTest.php
+++ b/tests/Unit/Event/EventTriggerServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Event;
 
 use Mockery as m;

--- a/tests/Unit/Query/ResolverTest.php
+++ b/tests/Unit/Query/ResolverTest.php
@@ -1,15 +1,14 @@
 <?php
 
-namespace Mongolid\Util;
+namespace Mongolid\Query;
 
 use Mockery as m;
 use MongoDB\BSON\ObjectId;
 use Mongolid\Model\ModelInterface;
-use Mongolid\Query\Resolver;
 use Mongolid\TestCase;
 use Mongolid\Tests\Stubs\Legacy\ProductWithSoftDelete;
 
-final class QueryBuilderTest extends TestCase
+final class ResolverTest extends TestCase
 {
     /**
      * @dataProvider queryValueScenarios
@@ -71,9 +70,8 @@ final class QueryBuilderTest extends TestCase
                 'isSoftDeleteEnabled' => false,
                 'expectation' => [
                     '_id' => [
-                        '$nin' => [new ObjectId(
-                            '507f1f77bcf86cd799439011'
-                        ),
+                        '$nin' => [
+                            new ObjectId('507f1f77bcf86cd799439011'),
                         ],
                     ],
                 ],
@@ -109,18 +107,18 @@ final class QueryBuilderTest extends TestCase
                 ],
             ],
             'When query is a objectId and softDelete is enabled' => [
-                'query' => $objectId,
+                'query' => new ObjectId('507f1f77bcf86cd799439011'),
                 'isSoftDeleteEnabled' => true,
                 'expected' => [
-                    '_id' => $objectId,
+                    '_id' => new ObjectId('507f1f77bcf86cd799439011'),
                     'deleted_at' => ['$exists' => false],
                 ],
             ],
             'When query is a objectId and softDelete is disabled' => [
-                'query' => $objectId,
+                'query' => new ObjectId('507f1f77bcf86cd799439011'),
                 'isSoftDeleteEnabled' => false,
                 'expected' => [
-                    '_id' => $objectId,
+                    '_id' => new ObjectId('507f1f77bcf86cd799439011'),
                 ],
             ],
         ];

--- a/tests/Unit/Schema/DynamicSchemaTest.php
+++ b/tests/Unit/Schema/DynamicSchemaTest.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace Mongolid;
+namespace Mongolid\Schema;
 
 use Mockery as m;
-use Mongolid\Schema\DynamicSchema;
-use Mongolid\Schema\Schema;
+use Mongolid\TestCase;
 
 class DynamicSchemaTest extends TestCase
 {
     public function tearDown(): void
     {
         parent::tearDown();
+
         m::close();
     }
 
-    public function testShouldExtendSchema()
+    public function testShouldExtendSchema(): void
     {
         // Arrange
         $schema = new DynamicSchema();
@@ -23,7 +23,7 @@ class DynamicSchemaTest extends TestCase
         $this->assertInstanceOf(Schema::class, $schema);
     }
 
-    public function testShouldBeDynamic()
+    public function testShouldBeDynamic(): void
     {
         // Arrange
         $schema = new DynamicSchema();

--- a/tests/Unit/Schema/SchemaTest.php
+++ b/tests/Unit/Schema/SchemaTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Mongolid;
+namespace Mongolid\Schema;
 
 use Mockery as m;
 use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\UTCDateTime;
 use Mongolid\Container\Container;
-use Mongolid\Schema\Schema;
+use Mongolid\TestCase;
 use Mongolid\Util\SequenceService;
 
 class SchemaTest extends TestCase
@@ -14,28 +14,29 @@ class SchemaTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
+
         m::close();
     }
 
-    public function testShouldNotBeDynamicByDefault()
+    public function testShouldNotBeDynamicByDefault(): void
     {
         // Arrange
-        $schema = m::mock(Schema::class.'[]');
+        $schema = m::mock(Schema::class . '[]');
 
         // Assert
-        $this->assertEquals(false,  $schema->dynamic);
+        $this->assertEquals(false, $schema->dynamic);
     }
 
-    public function testMustHaveAnEntityClass()
+    public function testMustHaveAnEntityClass(): void
     {
         // Arrange
-        $schema = m::mock(Schema::class.'[]');
+        $schema = m::mock(Schema::class . '[]');
 
         // Assert
         $this->assertEquals('stdClass', $schema->entityClass);
     }
 
-    public function testShouldCastNullIntoObjectId()
+    public function testShouldCastNullIntoObjectId(): void
     {
         // Arrange
         $schema = new class extends Schema {
@@ -49,7 +50,7 @@ class SchemaTest extends TestCase
         );
     }
 
-    public function testShouldNotCastRandomStringIntoObjectId()
+    public function testShouldNotCastRandomStringIntoObjectId(): void
     {
         // Arrange
         $schema = new class extends Schema {
@@ -63,7 +64,7 @@ class SchemaTest extends TestCase
         );
     }
 
-    public function testShouldCastObjectIdStringIntoObjectId()
+    public function testShouldCastObjectIdStringIntoObjectId(): void
     {
         // Arrange
         $schema = new class extends Schema {
@@ -82,7 +83,7 @@ class SchemaTest extends TestCase
         );
     }
 
-    public function testShouldCastNullIntoAutoIncrementSequence()
+    public function testShouldCastNullIntoAutoIncrementSequence(): void
     {
         // Arrange
         $schema = new class extends Schema {
@@ -104,7 +105,7 @@ class SchemaTest extends TestCase
         $this->assertEquals(7, $schema->sequence($value));
     }
 
-    public function testShouldNotAutoIncrementSequenceIfValueIsNotNull()
+    public function testShouldNotAutoIncrementSequenceIfValueIsNotNull(): void
     {
         $schema = new class extends Schema {
         };
@@ -125,7 +126,7 @@ class SchemaTest extends TestCase
         $this->assertEquals(3, $schema->sequence($value));
     }
 
-    public function testShouldCastDocumentTimestamps()
+    public function testShouldCastDocumentTimestamps(): void
     {
         // Arrange
         $schema = new class extends Schema {
@@ -139,7 +140,7 @@ class SchemaTest extends TestCase
         );
     }
 
-    public function testShouldRefreshUpdatedAtTimestamps()
+    public function testShouldRefreshUpdatedAtTimestamps(): void
     {
         // Arrange
         $schema = new class extends Schema {
@@ -159,20 +160,20 @@ class SchemaTest extends TestCase
         $value,
         $expectation,
         $compareTimestamp = true
-    ) {
+    ): void {
         // Arrange
         $schema = new class extends Schema {
         };
 
         // Assertion
         $result = $schema->createdAtTimestamp($value);
-        $this->assertInstanceOf(get_class($expectation), $result);
+        $this->assertInstanceOf($expectation::class, $result);
         if ($compareTimestamp) {
             $this->assertEquals((string) $expectation, (string) $result);
         }
     }
 
-    public function createdAtTimestampsFixture()
+    public function createdAtTimestampsFixture(): array
     {
         return [
             'MongoDB driver UTCDateTime' => [

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Mongolid;
 
 use Illuminate\Container\Container as IlluminateContainer;
@@ -6,13 +9,42 @@ use Mockery as m;
 use Mongolid\Container\Container;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionMethod;
 
 class TestCase extends PHPUnitTestCase
 {
+    public function assertMongoQueryEquals(array $expectedQuery, array $query): void
+    {
+        $this->assertEquals($expectedQuery, $query, 'Queries are not equals');
+
+        foreach ($expectedQuery as $key => $value) {
+            if (is_object($value)) {
+                $this->assertInstanceOf(
+                    $value::class,
+                    $query[$key],
+                    'Type of an object within the query is not equals'
+                );
+
+                if (method_exists($value, '__toString')) {
+                    $this->assertEquals(
+                        (string) $value,
+                        (string) $query[$key],
+                        'Object within the query is not equals'
+                    );
+                }
+            }
+
+            if (is_array($value)) {
+                $this->assertMongoQueryEquals($value, $query[$key]);
+            }
+        }
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
+
         Container::setContainer(new IlluminateContainer());
     }
 
@@ -20,20 +52,18 @@ class TestCase extends PHPUnitTestCase
     {
         Container::flush();
         m::close();
+
         parent::tearDown();
     }
 
     /**
      * Actually runs a protected method of the given object.
      *
-     * @param object $obj
-     * @param array  $args
-     *
-     * @return mixed
+     * @throws ReflectionException
      */
-    protected function callProtected($obj, string $method, array $args = [])
+    protected function callProtected(object|string $obj, string $method, array $args = []): mixed
     {
-        $methodObj = new ReflectionMethod(get_class($obj), $method);
+        $methodObj = new ReflectionMethod($obj::class, $method);
         $methodObj->setAccessible(true);
 
         return $methodObj->invokeArgs($obj, $args);
@@ -42,11 +72,9 @@ class TestCase extends PHPUnitTestCase
     /**
      * Set a protected property of an object.
      *
-     * @param mixed  $obj      object Instance
-     * @param string $property property name
-     * @param mixed  $value    value to be set
+     * @throws ReflectionException
      */
-    protected function setProtected($obj, string $property, $value): void
+    protected function setProtected(object|string $obj, string $property, mixed $value): void
     {
         $class = new ReflectionClass($obj);
         $property = $class->getProperty($property);
@@ -57,54 +85,27 @@ class TestCase extends PHPUnitTestCase
     /**
      * Get a protected property of an object.
      *
-     * @param mixed  $obj      object Instance
-     * @param string $property property name
-     *
-     * @return mixed property value
+     * @throws ReflectionException
      */
-    protected function getProtected($obj, string $property)
+    protected function getProtected(object|string $obj, string $property): mixed
     {
         $class = new ReflectionClass($obj);
         $property = $class->getProperty($property);
         $property->setAccessible(true);
+
         return $property->getValue($obj);
     }
 
     /**
      * Replace instance on Ioc
      */
-    protected function instance(string $abstract, $instance)
+    protected function instance(string $abstract, mixed $instance): mixed
     {
         Container::bind(
             $abstract,
-            function () use ($instance) {
-                return $instance;
-            }
+            fn () => $instance
         );
 
         return $instance;
-    }
-
-    public function assertMongoQueryEquals($expectedQuery, $query)
-    {
-        $this->assertEquals($expectedQuery, $query, 'Queries are not equals');
-
-        if (!is_array($expectedQuery)) {
-            return;
-        }
-
-        foreach ($expectedQuery as $key => $value) {
-            if (is_object($value)) {
-                $this->assertInstanceOf(get_class($value), $query[$key], 'Type of an object within the query is not equals');
-
-                if (method_exists($value, '__toString')) {
-                    $this->assertEquals((string) $expectedQuery[$key], (string) $query[$key], 'Object within the query is not equals');
-                }
-            }
-
-            if (is_array($value)) {
-                $this->assertMongoQueryEquals($value, $query[$key]);
-            }
-        }
     }
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -99,7 +99,7 @@ class TestCase extends PHPUnitTestCase
     /**
      * Replace instance on Ioc
      */
-    protected function instance(string $abstract, mixed $instance): mixed
+    protected function instance(string $abstract, object $instance): object
     {
         Container::bind(
             $abstract,

--- a/tests/Unit/Util/CacheComponentTest.php
+++ b/tests/Unit/Util/CacheComponentTest.php
@@ -3,22 +3,15 @@
 namespace Mongolid\Util;
 
 use Mockery as m;
+use Mockery\MockInterface;
 use Mongolid\TestCase;
 
 class CacheComponentTest extends TestCase
 {
     /**
      * Current time that will be retrieved by CacheComponent::time().
-     *
-     * @var int
      */
-    public $time = 1466710000;
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
-        m::close();
-    }
+    private int $time = 1466710000;
 
     public function testShouldImplementCacheComponentInterface(): void
     {
@@ -26,7 +19,10 @@ class CacheComponentTest extends TestCase
         $cacheComponent = (new CacheComponent());
 
         // Assertion
-        $this->assertInstanceOf(CacheComponentInterface::class, $cacheComponent);
+        $this->assertInstanceOf(
+            CacheComponentInterface::class,
+            $cacheComponent
+        );
     }
 
     public function testShouldPutAndRetrieveValues(): void
@@ -55,15 +51,12 @@ class CacheComponentTest extends TestCase
         $this->assertNull($cacheComponent->get('saveThe'));
     }
 
-    protected function getCacheComponent()
+    protected function getCacheComponent(): MockInterface
     {
-        $test = $this;
-        $cacheComponent = m::mock(CacheComponent::class.'[time]');
+        $cacheComponent = m::mock(CacheComponent::class . '[time]');
         $cacheComponent->shouldAllowMockingProtectedMethods();
         $cacheComponent->shouldReceive('time')
-            ->andReturnUsing(function () use ($test) {
-                return $test->time;
-            });
+            ->andReturnUsing(fn () => $this->time);
 
         return $cacheComponent;
     }
@@ -71,7 +64,7 @@ class CacheComponentTest extends TestCase
     /**
      * Skips $seconds of time.
      */
-    protected function tick($seconds)
+    protected function tick($seconds): void
     {
         $this->time += $seconds;
     }

--- a/tests/Unit/Util/LocalDateTimeTest.php
+++ b/tests/Unit/Util/LocalDateTimeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Util;
 
 use DateTime;
@@ -8,37 +9,9 @@ use Mongolid\TestCase;
 
 final class LocalDateTimeTest extends TestCase
 {
-    /**
-     * @var DateTime
-     */
-    protected $date;
+    private DateTime $date;
 
-    /**
-     * @var string
-     */
-    protected $format = 'd/m/Y H:i:s';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->date = new DateTime('01/05/2017 15:40:00');
-        $this->date->setTimezone(new DateTimeZone('UTC'));
-
-        date_default_timezone_set('America/Sao_Paulo');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown(): void
-    {
-        unset($this->date);
-        parent::tearDown();
-    }
+    private string $format = 'd/m/Y H:i:s';
 
     public function testGetShouldRetrievesDateUsingTimezone(): void
     {
@@ -93,5 +66,18 @@ final class LocalDateTimeTest extends TestCase
             DateTime::createFromFormat($timestamp, $this->format),
             DateTime::createFromFormat($mongoDateTimestamp, $this->format)
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->date = new DateTime('01/05/2017 15:40:00');
+        $this->date->setTimezone(new DateTimeZone('UTC'));
+
+        date_default_timezone_set('America/Sao_Paulo');
     }
 }

--- a/tests/Unit/Util/ObjectIdUtilsTest.php
+++ b/tests/Unit/Util/ObjectIdUtilsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Util;
 
 use MongoDB\BSON\ObjectId;
@@ -9,7 +10,7 @@ final class ObjectIdUtilsTest extends TestCase
     /**
      * @dataProvider objectIdStringScenarios
      */
-    public function testShouldEvaluateIfValueIsAnObjectId($value, bool $expectation): void
+    public function testShouldEvaluateIfValueIsAnObjectId(mixed $value, bool $expectation): void
     {
         // Actions
         $result = ObjectIdUtils::isObjectId($value);
@@ -21,7 +22,7 @@ final class ObjectIdUtilsTest extends TestCase
     public function objectIdStringScenarios(): array
     {
         $object = new class {
-            public function __toString()
+            public function __toString(): string
             {
                 return '577a68c44d3cec1f6c7796a2';
             }
@@ -35,7 +36,10 @@ final class ObjectIdUtilsTest extends TestCase
             ['value' => '507f191e810c19729de860ea', 'expectation' => true],
             ['value' => $object, 'expectation' => true],
             ['value' => new ObjectId(), 'expectation' => true],
-            ['value' => new ObjectId('577a68c44d3cec1f6c7796a2'), 'expectation' => true],
+            [
+                'value' => new ObjectId('577a68c44d3cec1f6c7796a2'),
+                'expectation' => true,
+            ],
             ['value' => 1, 'expectation' => false],
             ['value' => '507f191e810c197', 'expectation' => false],
             ['value' => 123456, 'expectation' => false],

--- a/tests/Unit/Util/SequenceServiceTest.php
+++ b/tests/Unit/Util/SequenceServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Util;
 
 use Mockery as m;
@@ -17,7 +18,10 @@ final class SequenceServiceTest extends TestCase
     {
         // Set
         $connection = m::mock(Connection::class);
-        $sequenceService = m::mock(SequenceService::class.'[rawCollection]', [$connection]);
+        $sequenceService = m::mock(
+            SequenceService::class . '[rawCollection]',
+            [$connection]
+        );
         $sequenceService->shouldAllowMockingProtectedMethods();
         $rawCollection = m::mock(Collection::class);
 
@@ -29,8 +33,14 @@ final class SequenceServiceTest extends TestCase
 
         $rawCollection
             ->expects('findOneAndUpdate')
-            ->with(['_id' => $sequenceName], ['$inc' => ['seq' => 1]], ['upsert' => true])
-            ->andReturn($currentValue ? (object) ['seq' => $currentValue] : null);
+            ->with(
+                ['_id' => $sequenceName],
+                ['$inc' => ['seq' => 1]],
+                ['upsert' => true]
+            )
+            ->andReturn(
+                $currentValue ? (object) ['seq' => $currentValue] : null
+            );
 
         // Actions
         $result = $sequenceService->getNextValue($sequenceName);


### PR DESCRIPTION
Connection was updating its internal property $defaultDatabase inside the method getClient().

Manager pulls the variable during setConnection(), with happens before connection->getClient() is called.

This cause the effect of not updating the defaultDatabase in time to be used on valid database exchanges. Causing the schema to always be called 'mongolid'.

This change updates the Connect->defaultDatabase during instantiation throught the __construct method. Updating the information in time to be pulled by Manager during setConnection.
Causing connection strings like this : 
$manager->setConnection(new Connection('mongodb://192.168.1.202:27017/WGL'));
 
To work correctly using WGL as the schema name.

Please let me know if this PR is acceptable, or how can I correct it.

Best regards.
