### PR TITLE
refactor: changed types and annotations for DataMapper context

### DIFF
--- a/src/DataMapper/DataMapper.php
+++ b/src/DataMapper/DataMapper.php
@@ -581,9 +581,9 @@ class DataMapper implements HasSchemaInterface
                 $changes['$set']["{$keyfix}{$k}"] = $v;
             } elseif ($oldData[$k] != $v) { // changed value
                 if (
-                    is_array($v) && is_array(
-                        $oldData[$k]
-                    ) && $v && [] !== $oldData[$k]
+                    $v && is_array($v) && 
+                    is_array($oldData[$k]) && 
+                    [] !== $oldData[$k]
                 ) { // check array recursively for changes
                     $this->calculateChanges(
                         $changes,

--- a/src/DataMapper/DataMapper.php
+++ b/src/DataMapper/DataMapper.php
@@ -115,11 +115,8 @@ class DataMapper implements HasSchemaInterface
     public function insert(mixed $entity, array $options = [], bool $fireEvents = true): bool
     {
         if (
-            $fireEvents && false === $this->fireEvent(
-                'inserting',
-                $entity,
-                true
-            )
+            $fireEvents && 
+            false === $this->fireEvent('inserting', $entity, true)
         ) {
             return false;
         }

--- a/src/DataMapper/EntityAssembler.php
+++ b/src/DataMapper/EntityAssembler.php
@@ -35,7 +35,10 @@ class EntityAssembler
             $fieldType = $schema->fields[$field] ?? null;
 
             if ($fieldType && str_starts_with($fieldType, 'schema.')) {
-                $value = $this->assembleDocumentsRecursively($value, substr($fieldType, 7));
+                $value = $this->assembleDocumentsRecursively(
+                    $value,
+                    substr($fieldType, 7)
+                );
             }
 
             $model->$field = $value;

--- a/src/DataMapper/SchemaMapper.php
+++ b/src/DataMapper/SchemaMapper.php
@@ -3,7 +3,6 @@
 namespace Mongolid\DataMapper;
 
 use Mongolid\Container\Container;
-use Mongolid\Container\Ioc;
 use Mongolid\Schema\Schema;
 
 /**
@@ -56,18 +55,6 @@ class SchemaMapper
     }
 
     /**
-     * If the schema is not dynamic, remove all non specified fields.
-     *
-     * @param array $data Reference of the fields. The passed array will be modified.
-     */
-    protected function clearDynamic(array &$data): void
-    {
-        if (!$this->schema->dynamic) {
-            $data = array_intersect_key($data, $this->schema->fields);
-        }
-    }
-
-    /**
      * Parse a value based on a field type of the schema.
      *
      * @param mixed  $value     value to be parsed
@@ -103,6 +90,18 @@ class SchemaMapper
         }
 
         return $value;
+    }
+
+    /**
+     * If the schema is not dynamic, remove all non specified fields.
+     *
+     * @param array $data Reference of the fields. The passed array will be modified.
+     */
+    protected function clearDynamic(array &$data): void
+    {
+        if (!$this->schema->dynamic) {
+            $data = array_intersect_key($data, $this->schema->fields);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR is the fourth in a series of PRs aimed at adding coding standards to Mongolid (the PR "https://github.com/leroy-merlin-br/mongolid/pull/247" is being split, and this is the first part, related to the DataMapper context).

The additions made here are being split from the PR:
https://github.com/leroy-merlin-br/mongolid/pull/209/files#diff-44c6c764ba381928e3221e4690c18dc0fe596311af5b123d5d2089ffc4db52af

And are beeing tested in the project : https://github.com/JoaoFerrazfs/Mongo-PHP-Docker_BaseProject