### PR TITLE
refactor: changed types and annotations for LegacyRecord

### DIFF
--- a/src/LegacyRecord.php
+++ b/src/LegacyRecord.php
@@ -33,7 +33,6 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
      * that are not specified in the $fields property. This is useful if you
      * does not have a strict document format or if you want to take full
      * advantage of the "schemaless" nature of MongoDB.
-     *
      */
     public bool $dynamic = true;
 
@@ -43,8 +42,6 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
      * models using this parameter. Every time this
      * model is queried, it will load its referenced
      * models together.
-     *
-     * @var array
      */
     public array $with = [];
 
@@ -78,7 +75,6 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
     /**
      * Whether the model should manage the `created_at` and `updated_at`
      * timestamps automatically.
-     *
      */
     protected bool $timestamps = true;
 
@@ -158,8 +154,6 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
 
     /**
      * Insert this object into database.
-     *
-     * @return bool Success
      */
     public function insert(): bool
     {
@@ -335,10 +329,9 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
      * Performs the given action into database.
      *
      * @param string $action datamapper function to execute
-     *
-     * @return bool
+     * @throws NoCollectionNameException
      */
-    protected function execute(string $action)
+    protected function execute(string $action): bool
     {
         if (!$this->getCollectionName()) {
             return false;
@@ -380,10 +373,8 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
      * @param mixed $parameters parameters of $method
      *
      * @throws BadMethodCallException in case of invalid methods be called
-     *
-     * @return mixed
      */
-    public function __call(mixed $method, mixed $parameters)
+    public function __call(mixed $method, mixed $parameters): mixed
     {
         $value = $parameters[0] ?? null;
 

--- a/src/LegacyRecord.php
+++ b/src/LegacyRecord.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -28,35 +29,11 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
     use HasLegacyRelationsTrait;
 
     /**
-     * Name of the collection where this kind of Entity is going to be saved or
-     * retrieved from.
-     */
-    protected ?string $collection = null;
-
-    /**
-     * @see https://docs.mongodb.com/manual/reference/write-concern/
-     */
-    protected int $writeConcern = 1;
-
-    /**
-     * Describes the Schema fields of the model. Optionally you can set it to
-     * the name of a Schema class to be used.
-     *
-     * @see  Mongolid\Schema\Schema::$fields
-     *
-     * @var string[] | string
- */
-    protected array | string $fields = [
-        '_id' => 'objectId',
-        'created_at' => 'createdAtTimestamp',
-        'updated_at' => 'updatedAtTimestamp',
-    ];
-
-    /**
      * The $dynamic property tells if the object will accept additional fields
      * that are not specified in the $fields property. This is useful if you
      * does not have a strict document format or if you want to take full
      * advantage of the "schemaless" nature of MongoDB.
+     *
      */
     public bool $dynamic = true;
 
@@ -66,82 +43,44 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
      * models using this parameter. Every time this
      * model is queried, it will load its referenced
      * models together.
+     *
+     * @var array
      */
     public array $with = [];
+
+    /**
+     * Name of the collection where this kind of Entity is going to be saved or
+     * retrieved from.
+     *
+     */
+    protected ?string $collection = null;
+
+    /**
+     * @see https://docs.mongodb.com/manual/reference/write-concern/
+     *
+     */
+    protected int $writeConcern = 1;
+
+    /**
+     * Describes the Schema fields of the model. Optionally you can set it to
+     * the name of a Schema class to be used.
+     *
+     * @see  Mongolid\Schema\Schema::$fields
+     *
+     * @var string|string[]
+     */
+    protected string|array $fields = [
+        '_id' => 'objectId',
+        'created_at' => 'createdAtTimestamp',
+        'updated_at' => 'updatedAtTimestamp',
+    ];
 
     /**
      * Whether the model should manage the `created_at` and `updated_at`
      * timestamps automatically.
      *
-     * @var bool
      */
-    protected $timestamps = true;
-
-    /**
-     * Saves this object into database.
-     */
-    public function save(): bool
-    {
-        return $this->execute('save');
-    }
-
-    /**
-     * Insert this object into database.
-     *
-     * @return bool Success
-     */
-    public function insert(): bool
-    {
-        return $this->execute('insert');
-    }
-
-    /**
-     * Updates this object in database.
-     */
-    public function update(): bool
-    {
-        return $this->execute('update');
-    }
-
-    /**
-     * Deletes this object in database.
-     */
-    public function delete(): bool
-    {
-        if ($this->isSoftDeleteEnabled ?? false) {
-            return $this->executeSoftDelete();
-        }
-
-        return $this->execute('delete');
-    }
-
-    /**
-     * Gets a cursor of this kind of entities that matches the query from the
-     * database.
-     *
-     * @param array $query      mongoDB selection criteria
-     * @param array $projection fields to project in Mongo query
-     * @param bool  $useCache   retrieves a CacheableCursor instead
-     */
-    public static function where(
-        array $query = [],
-        array $projection = [],
-        bool $useCache = false
-    ): CursorInterface {
-        return self::getDataMapperInstance()->where(
-            $query,
-            $projection,
-            $useCache
-        );
-    }
-
-    /**
-     * Gets a cursor of this kind of entities from the database.
-     */
-    public static function all(): CursorInterface
-    {
-        return self::getDataMapperInstance()->all();
-    }
+    protected bool $timestamps = true;
 
     /**
      * Gets the first entity of this kind that matches the query.
@@ -210,38 +149,41 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
     }
 
     /**
-     * Handle dynamic method calls into the model.
-     *
-     * @param string $method     name of the method that is being called
-     * @param array $parameters parameters of $method
-     *
-     * @throws BadMethodCallException in case of invalid methods be called
+     * Saves this object into database.
      */
-    public function __call(string $method, array $parameters): mixed
+    public function save(): bool
     {
-        $value = $parameters[0] ?? null;
+        return $this->execute('save');
+    }
 
-        // Alias to attach
-        if (str_starts_with($method, 'attachTo')) {
-            $field = lcfirst(substr($method, 8));
+    /**
+     * Insert this object into database.
+     *
+     * @return bool Success
+     */
+    public function insert(): bool
+    {
+        return $this->execute('insert');
+    }
 
-            return $this->attach($field, $value);
+    /**
+     * Updates this object in database.
+     */
+    public function update(): bool
+    {
+        return $this->execute('update');
+    }
+
+    /**
+     * Deletes this object in database.
+     */
+    public function delete(): bool
+    {
+        if ($this->isSoftDeleteEnabled ?? false) {
+            return $this->executeSoftDelete();
         }
 
-        // Alias to embed
-        if (str_starts_with($method, 'embedTo')) {
-            $field = lcfirst(substr($method, 7));
-
-            return $this->embed($field, $value);
-        }
-
-        throw new BadMethodCallException(
-            sprintf(
-                'The following method can not be reached or does not exist: %s@%s',
-                static::class,
-                $method
-            )
-        );
+        return $this->execute('delete');
     }
 
     /**
@@ -306,6 +248,69 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
         return $schema;
     }
 
+    public function getCollection(): Collection
+    {
+        return $this->getDataMapper()
+            ->getCollection();
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function bsonSerialize(): object|array
+    {
+        return Container::make(ModelMapper::class)
+            ->map(
+                $this,
+                array_merge($this->fillable, $this->guarded),
+                $this->dynamic,
+                $this->timestamps
+            );
+    }
+
+    public function bsonUnserialize(array $data): void
+    {
+        $this->fill($data, true);
+
+        $this->syncOriginalDocumentAttributes();
+    }
+
+    /**
+     * Query model on database to retrieve an updated version of its attributes.
+     */
+    public function fresh(): self
+    {
+        return static::first($this->_id);
+    }
+
+    /**
+     * Gets a cursor of this kind of entities that matches the query from the
+     * database.
+     *
+     * @param array $query      mongoDB selection criteria
+     * @param array $projection fields to project in Mongo query
+     * @param bool  $useCache   retrieves a CacheableCursor instead
+     */
+    public static function where(
+        array $query = [],
+        array $projection = [],
+        bool $useCache = false
+    ): CursorInterface {
+        return self::getDataMapperInstance()->where(
+            $query,
+            $projection,
+            $useCache
+        );
+    }
+
+    /**
+     * Gets a cursor of this kind of entities from the database.
+     */
+    public static function all(): CursorInterface
+    {
+        return self::getDataMapperInstance()->all();
+    }
+
     /**
      * Will check if the current value of $fields property is the name of a
      * Schema class and instantiate it if possible.
@@ -313,7 +318,12 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
     protected function instantiateSchemaInFields(): ?Schema
     {
         if (is_string($this->fields)) {
-            if (is_subclass_of($instance = Container::make($this->fields), Schema::class)) {
+            if (
+                is_subclass_of(
+                    $instance = Container::make($this->fields),
+                    Schema::class
+                )
+            ) {
                 return $instance;
             }
         }
@@ -325,8 +335,10 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
      * Performs the given action into database.
      *
      * @param string $action datamapper function to execute
+     *
+     * @return bool
      */
-    protected function execute(string $action): bool
+    protected function execute(string $action)
     {
         if (!$this->getCollectionName()) {
             return false;
@@ -361,34 +373,40 @@ class LegacyRecord implements ModelInterface, HasSchemaInterface
         return $instance->getDataMapper();
     }
 
-    public function getCollection(): Collection
-    {
-        return $this->getDataMapper()
-            ->getCollection();
-    }
-
     /**
-     * @return array|object
-     * @throws BindingResolutionException
+     * Handle dynamic method calls into the model.
+     *
+     * @param mixed $method     name of the method that is being called
+     * @param mixed $parameters parameters of $method
+     *
+     * @throws BadMethodCallException in case of invalid methods be called
+     *
+     * @return mixed
      */
-    public function bsonSerialize(): object|array
+    public function __call(mixed $method, mixed $parameters)
     {
-        return Container::make(ModelMapper::class)
-            ->map($this, array_merge($this->fillable, $this->guarded), $this->dynamic, $this->timestamps);
-    }
+        $value = $parameters[0] ?? null;
 
-    public function bsonUnserialize(array $data): void
-    {
-        $this->fill($data, true);
+        // Alias to attach
+        if (str_starts_with($method, 'attachTo')) {
+            $field = lcfirst(substr($method, 8));
 
-        $this->syncOriginalDocumentAttributes();
-    }
+            return $this->attach($field, $value);
+        }
 
-    /**
-     * Query model on database to retrieve an updated version of its attributes.
-     */
-    public function fresh(): self
-    {
-        return $this->first($this->_id);
+        // Alias to embed
+        if (str_starts_with($method, 'embedTo')) {
+            $field = lcfirst(substr($method, 7));
+
+            return $this->embed($field, $value);
+        }
+
+        throw new BadMethodCallException(
+            sprintf(
+                'The following method can not be reached or does not exist: %s@%s',
+                static::class,
+                $method
+            )
+        );
     }
 }

--- a/tests/Stubs/EmbeddedUser.php
+++ b/tests/Stubs/EmbeddedUser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;

--- a/tests/Stubs/ExpirablePrice.php
+++ b/tests/Stubs/ExpirablePrice.php
@@ -2,8 +2,6 @@
 
 namespace Mongolid\Tests\Stubs;
 
-use DateTime;
-
 class ExpirablePrice extends Price
 {
     protected array $casts = [

--- a/tests/Stubs/Legacy/LegacyRecordUser.php
+++ b/tests/Stubs/Legacy/LegacyRecordUser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs\Legacy;
 
 use Mongolid\Cursor\CursorInterface;
@@ -6,16 +7,13 @@ use Mongolid\LegacyRecord;
 
 class LegacyRecordUser extends LegacyRecord
 {
-    protected ?string $collection = 'users';
-
     public bool $mutable = true;
 
-    /**
-     * @var bool
-     */
-    protected $timestamps = true;
-
     public bool $dynamic = false;
+
+    protected ?string $collection = 'users';
+
+    protected bool $timestamps = true;
 
     protected array $fillable = [
         'name',

--- a/tests/Stubs/Legacy/Product.php
+++ b/tests/Stubs/Legacy/Product.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs\Legacy;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -8,18 +9,18 @@ use Mongolid\Tests\Stubs\Price;
 
 class Product extends LegacyRecord
 {
-    protected ?string $collection = 'products';
-
     public array $with = [
         'price' => [
             'key' => '_id',
-            'model' => Price::class
+            'model' => Price::class,
         ],
         'shop' => [
             'key' => 'skus.shop_id',
             'model' => Shop::class,
         ],
     ];
+
+    protected ?string $collection = 'products';
 
     /**
      * @throws BindingResolutionException

--- a/tests/Stubs/Legacy/Shop.php
+++ b/tests/Stubs/Legacy/Shop.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs\Legacy;
 
 use Mongolid\LegacyRecord;

--- a/tests/Stubs/Legacy/Sku.php
+++ b/tests/Stubs/Legacy/Sku.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs\Legacy;
 
 use Illuminate\Contracts\Container\BindingResolutionException;

--- a/tests/Stubs/PolymorphedReferencedUser.php
+++ b/tests/Stubs/PolymorphedReferencedUser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 class PolymorphedReferencedUser extends ReferencedUser

--- a/tests/Stubs/Price.php
+++ b/tests/Stubs/Price.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;

--- a/tests/Stubs/Product.php
+++ b/tests/Stubs/Product.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;

--- a/tests/Stubs/ReferencedUser.php
+++ b/tests/Stubs/ReferencedUser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;
@@ -30,7 +31,11 @@ class ReferencedUser extends AbstractModel implements PolymorphableModelInterfac
 
     public function son(): ReferencesOne
     {
-        return $this->referencesOne(ReferencedUser::class, 'arbitrary_field', 'code');
+        return $this->referencesOne(
+            ReferencedUser::class,
+            'arbitrary_field',
+            'code'
+        );
     }
 
     public function grandsons(): ReferencesMany

--- a/tests/Stubs/ReplaceCollectionModel.php
+++ b/tests/Stubs/ReplaceCollectionModel.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use MongoDB\Collection;


### PR DESCRIPTION
This PR is the fifth in a series of PRs aimed at adding coding standards to Mongolid (the PR "https://github.com/leroy-merlin-br/mongolid/pull/247" is being split, and this is the second part, related to LegacyRecord).

The additions made here are being split from the PR: 
https://github.com/leroy-merlin-br/mongolid/pull/209/files#diff-44c6c764ba381928e3221e4690c18dc0fe596311af5b123d5d2089ffc4db52af

And are tested in the project: https://github.com/JoaoFerrazfs/Mongo-PHP-Docker_BaseProject