### PR TITLE
refactor: changed types and annotations for Query context

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Query;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -8,7 +9,6 @@ use Mongolid\Container\Container;
 use Mongolid\Cursor\CacheableCursor;
 use Mongolid\Cursor\Cursor;
 use Mongolid\Cursor\CursorInterface;
-use Mongolid\Cursor\EagerLoadingCursor;
 use Mongolid\Event\EventTriggerService;
 use Mongolid\Model\Exception\ModelNotFoundException;
 use Mongolid\Model\Exception\NoCollectionNameException;
@@ -20,12 +20,12 @@ use Mongolid\Model\ModelInterface;
  */
 class Builder
 {
-    private bool $ignoreSoftDelete = false;
-
     /**
      * In order to dispatch events when necessary.
      */
     protected ?EventTriggerService $eventService = null;
+
+    private bool $ignoreSoftDelete = false;
 
     public function __construct(
         /**
@@ -42,8 +42,8 @@ class Builder
      * Notice: Saves with Unacknowledged WriteConcern will not fire `saved` event.
      * Return is always false if write concern is Unacknowledged.
      *
-     * @param ModelInterface $model the model used in the operation
-     * @param array $options possible options to send to mongo driver
+     * @param ModelInterface $model   the model used in the operation
+     * @param array          $options possible options to send to mongo driver
      * @throws BindingResolutionException
      * @throws NoCollectionNameException
      */
@@ -65,7 +65,7 @@ class Builder
         );
 
         $result = $queryResult->isAcknowledged() &&
-                  ($queryResult->getModifiedCount() || $queryResult->getUpsertedCount());
+            ($queryResult->getModifiedCount() || $queryResult->getUpsertedCount());
 
         if ($result) {
             $this->afterSuccess($model);
@@ -84,15 +84,21 @@ class Builder
      * Notice: Inserts with Unacknowledged WriteConcern will not fire `inserted` event.
      * Return is always false if write concern is Unacknowledged.
      *
-     * @param ModelInterface $model the model used in the operation
-     * @param array $options possible options to send to mongo driver
-     * @param bool $fireEvents whether events should be fired
+     * @param ModelInterface $model      the model used in the operation
+     * @param array          $options    possible options to send to mongo driver
+     * @param bool           $fireEvents whether events should be fired
      * @throws BindingResolutionException
      * @throws NoCollectionNameException
      */
     public function insert(ModelInterface $model, array $options = [], bool $fireEvents = true): bool
     {
-        if ($fireEvents && false === $this->fireEvent('inserting', $model, true)) {
+        if (
+            $fireEvents && false === $this->fireEvent(
+                'inserting',
+                $model,
+                true
+            )
+        ) {
             return false;
         }
 
@@ -122,8 +128,8 @@ class Builder
      * Notice: Updates with Unacknowledged WriteConcern will not fire `updated` event.
      * Return is always false if write concern is Unacknowledged.
      *
-     * @param ModelInterface $model the model used in the operation
-     * @param array $options possible options to send to mongo driver
+     * @param ModelInterface $model   the model used in the operation
+     * @param array          $options possible options to send to mongo driver
      * @throws BindingResolutionException
      * @throws NoCollectionNameException
      */
@@ -168,8 +174,8 @@ class Builder
      * Notice: Deletes with Unacknowledged WriteConcern will not fire `deleted` event.
      * Return is always false if write concern is Unacknowledged.
      *
-     * @param ModelInterface $model the model used in the operation
-     * @param array $options possible options to send to mongo driver
+     * @param ModelInterface $model   the model used in the operation
+     * @param array          $options possible options to send to mongo driver
      * @throws BindingResolutionException
      * @throws NoCollectionNameException
      */
@@ -184,7 +190,8 @@ class Builder
             $this->mergeOptions($options)
         );
 
-        if ($queryResult->isAcknowledged() &&
+        if (
+            $queryResult->isAcknowledged() &&
             $queryResult->getDeletedCount()
         ) {
             $this->fireEvent('deleted', $model);
@@ -204,8 +211,12 @@ class Builder
      * @param bool           $useCache   retrieves a CacheableCursor instead
      * @throws NoCollectionNameException
      */
-    public function where(ModelInterface $model, mixed $query = [], array $projection = [], bool $useCache = false): CursorInterface
-    {
+    public function where(
+        ModelInterface $model,
+        mixed $query = [],
+        array $projection = [],
+        bool $useCache = false
+    ): CursorInterface {
         $cursor = $useCache ? CacheableCursor::class : Cursor::class;
 
         $query = Resolver::resolveQuery(
@@ -213,6 +224,7 @@ class Builder
             $model,
             $this->ignoreSoftDelete
         );
+
         return new $cursor(
             $model->getCollection(),
             'find',
@@ -242,19 +254,28 @@ class Builder
      * @param ModelInterface $model      Model to query from collection
      * @param mixed          $query      MongoDB query to retrieve the model
      * @param array          $projection fields to project in MongoDB query
-     * @param boolean        $useCache   retrieves the first through a CacheableCursor
+     * @param bool           $useCache   retrieves the first through a CacheableCursor
      *
      * @return ModelInterface|array|null
      * @throws NoCollectionNameException
      */
-    public function first(ModelInterface $model, mixed $query = [], array $projection = [], bool $useCache = false): mixed
-    {
+    public function first(
+        ModelInterface $model,
+        mixed $query = [],
+        array $projection = [],
+        bool $useCache = false
+    ): mixed {
         if (null === $query) {
             return null;
         }
 
         if ($useCache) {
-            return $this->where($model, $query, $projection, $useCache)->first();
+            return $this->where(
+                $model,
+                $query,
+                $projection,
+                $useCache
+            )->first();
         }
 
         $query = Resolver::resolveQuery(
@@ -275,14 +296,18 @@ class Builder
      * @param ModelInterface $model      Model to query from collection
      * @param mixed          $query      MongoDB query to retrieve the model
      * @param array          $projection fields to project in MongoDB query
-     * @param boolean        $useCache   retrieves the first through a CacheableCursor
+     * @param bool           $useCache   retrieves the first through a CacheableCursor
      *
-     * @return ModelInterface|null|array
+     * @return ModelInterface|array|null
      *
      * @throws ModelNotFoundException|NoCollectionNameException If no model was found
      */
-    public function firstOrFail(ModelInterface $model, mixed $query = [], array $projection = [], bool $useCache = false): mixed
-    {
+    public function firstOrFail(
+        ModelInterface $model,
+        mixed $query = [],
+        array $projection = [],
+        bool $useCache = false
+    ): mixed {
         if ($result = $this->first($model, $query, $projection, $useCache)) {
             return $result;
         }
@@ -300,16 +325,16 @@ class Builder
     /**
      * Triggers an event. May return if that event had success.
      *
-     * @param string $event identification of the event
+     * @param string         $event identification of the event
      * @param ModelInterface $model event payload
-     * @param bool $halt true if the return of the event handler will be used in a conditional
+     * @param bool           $halt  true if the return of the event handler will be used in a conditional
      *
      * @return mixed event handler return
      * @throws BindingResolutionException
      */
     protected function fireEvent(string $event, ModelInterface $model, bool $halt = false): mixed
     {
-        $event = "mongolid.{$event}: ".$model::class;
+        $event = "mongolid.{$event}: " . $model::class;
 
         if (!$this->eventService) {
             $this->eventService = Container::make(EventTriggerService::class);
@@ -397,9 +422,18 @@ class Builder
         foreach ($newData as $k => $v) {
             if (!isset($oldData[$k])) { // new field
                 $changes['$set']["{$keyfix}{$k}"] = $v;
-            } elseif ($oldData[$k] != $v) {  // changed value
-                if (is_array($v) && is_array($oldData[$k]) && $v) { // check array recursively for changes
-                    $this->calculateChanges($changes, $v, $oldData[$k], "{$keyfix}{$k}.");
+            } elseif ($oldData[$k] != $v) { // changed value
+                if (
+                    is_array($v) && is_array(
+                        $oldData[$k]
+                    ) && $v
+                ) { // check array recursively for changes
+                    $this->calculateChanges(
+                        $changes,
+                        $v,
+                        $oldData[$k],
+                        "{$keyfix}{$k}."
+                    );
                 } else {
                     // overwrite normal changes in keys
                     // this applies to previously empty arrays/documents too
@@ -437,7 +471,11 @@ class Builder
     private function getUpdateData(ModelInterface $model, array $data): array
     {
         $changes = [];
-        $this->calculateChanges($changes, $data, $model->getOriginalDocumentAttributes());
+        $this->calculateChanges(
+            $changes,
+            $data,
+            $model->getOriginalDocumentAttributes()
+        );
 
         return $changes;
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -93,11 +93,8 @@ class Builder
     public function insert(ModelInterface $model, array $options = [], bool $fireEvents = true): bool
     {
         if (
-            $fireEvents && false === $this->fireEvent(
-                'inserting',
-                $model,
-                true
-            )
+            $fireEvents && 
+            false === $this->fireEvent('inserting', $model, true)
         ) {
             return false;
         }
@@ -424,9 +421,8 @@ class Builder
                 $changes['$set']["{$keyfix}{$k}"] = $v;
             } elseif ($oldData[$k] != $v) { // changed value
                 if (
-                    is_array($v) && is_array(
-                        $oldData[$k]
-                    ) && $v
+                    $v && is_array($v) && 
+                    is_array($oldData[$k])
                 ) { // check array recursively for changes
                     $this->calculateChanges(
                         $changes,

--- a/src/Query/BulkWrite.php
+++ b/src/Query/BulkWrite.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Query;
 
 use MongoDB\BSON\ObjectId;

--- a/src/Query/EagerLoader/CacheKeyGeneratorTrait.php
+++ b/src/Query/EagerLoader/CacheKeyGeneratorTrait.php
@@ -6,7 +6,7 @@ use Mongolid\Model\ModelInterface;
 
 trait CacheKeyGeneratorTrait
 {
-    public function generateCacheKey(ModelInterface $model, string $id = null): string
+    public function generateCacheKey(ModelInterface $model, ?string $id = null): string
     {
         if (is_null($id)) {
             $id = (string) $model->_id;

--- a/src/Query/EagerLoader/EagerLoader.php
+++ b/src/Query/EagerLoader/EagerLoader.php
@@ -1,11 +1,9 @@
 <?php
+
 namespace Mongolid\Query\EagerLoader;
 
 use Iterator;
-use MongoDB\BSON\ObjectId;
 use Mongolid\Container\Container;
-use Mongolid\Model\ModelInterface;
-use Mongolid\Util\CacheComponentInterface;
 
 /**
  * This class is responsible for caching all related models

--- a/src/Query/EagerLoader/Extractor.php
+++ b/src/Query/EagerLoader/Extractor.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Mongolid\Query\EagerLoader;
 
 use MongoDB\BSON\ObjectId;
 use Mongolid\Query\EagerLoader\Exception\EagerLoaderException;
-use Mongolid\Query\EagerLoader\Exception\InvalidModelKeyException;
 
 /**
  * Responsible for extract ids from the model based on its
@@ -95,7 +95,9 @@ class Extractor
             // In case the referenced key on parent model was not
             // found on related model, we should warn that the user
             // is trying to eager load an invalid model.
-            throw new EagerLoaderException('Referenced key was not found on child model.');
+            throw new EagerLoaderException(
+                'Referenced key was not found on child model.'
+            );
         }
 
         // We only want to object ids to string to give

--- a/src/Query/ModelMapper.php
+++ b/src/Query/ModelMapper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Query;
 
 use MongoDB\BSON\ObjectId;
@@ -19,7 +20,12 @@ class ModelMapper
     public function map(ModelInterface $model, array $allowedFields, bool $dynamic, bool $timestamps): array
     {
         $this->clearNullFields($model);
-        $this->clearDynamicFields($model, $allowedFields, $dynamic, $timestamps);
+        $this->clearDynamicFields(
+            $model,
+            $allowedFields,
+            $dynamic,
+            $timestamps
+        );
         $this->manageTimestamps($model, $timestamps);
         $this->manageId($model);
 
@@ -69,7 +75,10 @@ class ModelMapper
         if (!$timestamps) {
             return;
         }
-        $model->updated_at = Container::make(UTCDateTime::class, ['milliseconds' => null]);
+        $model->updated_at = Container::make(
+            UTCDateTime::class,
+            ['milliseconds' => null]
+        );
 
         if (!$model->created_at instanceof UTCDateTime) {
             $model->created_at = $model->updated_at;
@@ -80,7 +89,11 @@ class ModelMapper
     {
         $value = $model->_id;
 
-        if (is_null($value) || (is_string($value) && ObjectIdUtils::isObjectId($value))) {
+        if (
+            is_null($value) || (is_string($value) && ObjectIdUtils::isObjectId(
+                    $value
+                ))
+        ) {
             $value = Container::make(ObjectId::class, ['id' => $value]);
         }
 

--- a/src/Query/ModelMapper.php
+++ b/src/Query/ModelMapper.php
@@ -90,9 +90,10 @@ class ModelMapper
         $value = $model->_id;
 
         if (
-            is_null($value) || (is_string($value) && ObjectIdUtils::isObjectId(
-                    $value
-                ))
+            is_null($value) || 
+            (
+                is_string($value) && ObjectIdUtils::isObjectId($value)
+            )
         ) {
             $value = Container::make(ObjectId::class, ['id' => $value]);
         }


### PR DESCRIPTION
This PR is the seventh in a series of PRs aimed at adding coding standards to Mongolid (the PR "https://github.com/leroy-merlin-br/mongolid/pull/247" is being split, and this is the fourth part, related to the Query context).

The additions made here are being split from the PR: 
https://github.com/leroy-merlin-br/mongolid/pull/209/files#diff-44c6c764ba381928e3221e4690c18dc0fe596311af5b123d5d2089ffc4db52af

And are tested in the project: https://github.com/JoaoFerrazfs/Mongo-PHP-Docker_BaseProject