### PR TITLE
refactor: changed types and annotations for Integration Tests context

### DIFF
--- a/tests/Integration/AttributesKeyTest.php
+++ b/tests/Integration/AttributesKeyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use Mongolid\Tests\Stubs\ReferencedUser;
@@ -18,7 +19,10 @@ final class AttributesKeyTest extends IntegrationTestCase
         $this->assertSame('John', $user->name);
         $this->assertSame('john@doe.com', $user->email);
         $this->assertSame(['my', 'attributes'], $user->attributes);
-        $this->assertSame(['my', 'original', 'attributes'], $user->originalAttributes);
+        $this->assertSame(
+            ['my', 'original', 'attributes'],
+            $user->originalAttributes
+        );
         $this->assertSame(
             [
                 'name' => 'John',
@@ -37,7 +41,10 @@ final class AttributesKeyTest extends IntegrationTestCase
         $this->assertSame('John', $user->name);
         $this->assertSame('john@doe.com', $user->email);
         $this->assertSame(['my', 'attributes'], $user->attributes);
-        $this->assertSame(['my', 'original', 'attributes'], $user->originalAttributes);
+        $this->assertSame(
+            ['my', 'original', 'attributes'],
+            $user->originalAttributes
+        );
         $this->assertSame(
             [
                 '_id' => $user->_id,

--- a/tests/Integration/BulkWriteTest.php
+++ b/tests/Integration/BulkWriteTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use MongoDB\BSON\ObjectId;

--- a/tests/Integration/DateQueriesTest.php
+++ b/tests/Integration/DateQueriesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use DateTime;
@@ -11,14 +12,18 @@ final class DateQueriesTest extends IntegrationTestCase
     {
         // Set
         $user = new ReferencedUser();
-        $user->some_date = new UTCDateTime(new DateTime('2018-10-10 00:00:00'));
+        $user->some_date = new UTCDateTime(
+            new DateTime('2018-10-10 00:00:00')
+        );
 
         $this->assertTrue($user->save());
 
         $greaterEqualResult = ReferencedUser::where(
             [
                 'some_date' => [
-                    '$gte' => new UTCDateTime(new DateTime('2018-10-10 00:00:00')),
+                    '$gte' => new UTCDateTime(
+                        new DateTime('2018-10-10 00:00:00')
+                    ),
                 ],
             ]
         );
@@ -29,7 +34,9 @@ final class DateQueriesTest extends IntegrationTestCase
         $greaterResult = ReferencedUser::where(
             [
                 'some_date' => [
-                    '$gt' => new UTCDateTime(new DateTime('2018-10-10 00:00:00')),
+                    '$gt' => new UTCDateTime(
+                        new DateTime('2018-10-10 00:00:00')
+                    ),
                 ],
             ]
         );
@@ -39,7 +46,9 @@ final class DateQueriesTest extends IntegrationTestCase
         $emptyResult = ReferencedUser::where(
             [
                 'some_date' => [
-                    '$gte' => new UTCDateTime(new DateTime('2018-10-10 00:00:01')),
+                    '$gte' => new UTCDateTime(
+                        new DateTime('2018-10-10 00:00:01')
+                    ),
                 ],
             ]
         );
@@ -80,7 +89,9 @@ final class DateQueriesTest extends IntegrationTestCase
         $emptyResult = ReferencedUser::where(
             [
                 'some_date' => [
-                    '$gte' => new UTCDateTime(new DateTime('+10 days +1 second')),
+                    '$gte' => new UTCDateTime(
+                        new DateTime('+10 days +1 second')
+                    ),
                 ],
             ]
         );

--- a/tests/Integration/DateTimeCastTest.php
+++ b/tests/Integration/DateTimeCastTest.php
@@ -23,13 +23,18 @@ class DateTimeCastTest extends IntegrationTestCase
 
         // Assertions
         $this->assertInstanceOf(DateTime::class, $price->expires_at);
-        $this->assertInstanceOf(UTCDateTime::class, $price->getOriginalDocumentAttributes()['expires_at']);
+        $this->assertInstanceOf(
+            UTCDateTime::class,
+            $price->getOriginalDocumentAttributes()['expires_at']
+        );
 
         $price = ExpirablePrice::first($price->_id);
         $this->assertSame('02/10/2025', $price->expires_at->format('d/m/Y'));
         $this->assertSame(
             '02/10/2025',
-            LocalDateTime::get($price->getOriginalDocumentAttributes()['expires_at'])
+            LocalDateTime::get(
+                $price->getOriginalDocumentAttributes()['expires_at']
+            )
                 ->format('d/m/Y')
         );
     }
@@ -57,13 +62,19 @@ class DateTimeCastTest extends IntegrationTestCase
                 'expires_at' => 'datetime',
             ];
         };
-        $entity->expires_at = DateTime::createFromFormat('d/m/Y', '02/10/2025');
+        $entity->expires_at = DateTime::createFromFormat(
+            'd/m/Y',
+            '02/10/2025'
+        );
 
         // Actions
         $entity->save();
 
         // Assertions
         $this->assertInstanceOf(DateTime::class, $entity->expires_at);
-        $this->assertInstanceOf(UTCDateTime::class, $entity->getOriginalDocumentAttributes()['expires_at']);
+        $this->assertInstanceOf(
+            UTCDateTime::class,
+            $entity->getOriginalDocumentAttributes()['expires_at']
+        );
     }
 }

--- a/tests/Integration/EagerLoadingTest.php
+++ b/tests/Integration/EagerLoadingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use Mongolid\Container\Container;
@@ -13,7 +14,10 @@ final class EagerLoadingTest extends IntegrationTestCase
 {
     public function testShouldEagerLoadingAllShops(): void
     {
-        $cache = Container::instance(CacheComponentInterface::class, new CacheComponent);
+        $cache = Container::instance(
+            CacheComponentInterface::class,
+            new CacheComponent()
+        );
         $product1 = $this->createProductWithPrice('Playstation', 299.90);
         $product2 = $this->createProductWithPrice('Xbox', 199.90);
         $product3 = $this->createProductWithPrice('Switch', 399.90);
@@ -48,7 +52,10 @@ final class EagerLoadingTest extends IntegrationTestCase
 
     public function testShouldEagerLoadOnlyACertainLimitOfProducts(): void
     {
-        $cache = Container::instance(CacheComponentInterface::class, new CacheComponent);
+        $cache = Container::instance(
+            CacheComponentInterface::class,
+            new CacheComponent()
+        );
         $cacheLimit = 100;
 
         for ($i = 1; $i < 101; $i++) { // DOCUMENT_LIMIT+1

--- a/tests/Integration/EmbedsManyRelationTest.php
+++ b/tests/Integration/EmbedsManyRelationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use Illuminate\Support\Arr;
@@ -62,7 +63,11 @@ final class EmbedsManyRelationTest extends IntegrationTestCase
         // changing the field with fillable
         $john->siblings()->add($bob);
         $this->assertSiblings([$bob], $john);
-        $john = EmbeddedUser::fill(['embedded_siblings' => [$chuck]], $john, true);
+        $john = EmbeddedUser::fill(
+            ['embedded_siblings' => [$chuck]],
+            $john,
+            true
+        );
         $this->assertSiblings([$chuck], $john);
     }
 
@@ -120,14 +125,21 @@ final class EmbedsManyRelationTest extends IntegrationTestCase
         // changing the field with fillable
         $john->grandsons()->add($bob);
         $this->assertGrandsons([$bob], $john);
-        $john = EmbeddedUser::fill(['other_arbitrary_field' => [$chuck]], $john, true);
+        $john = EmbeddedUser::fill(
+            ['other_arbitrary_field' => [$chuck]],
+            $john,
+            true
+        );
         $this->assertGrandsons([$chuck], $john);
 
         // save and retrieve object
         $this->assertTrue($john->save());
         $john = $john->first($john->_id);
 
-        $this->assertInstanceOf(EmbeddedUser::class, $john->grandsons->first());
+        $this->assertInstanceOf(
+            EmbeddedUser::class,
+            $john->grandsons->first()
+        );
         $this->assertEquals(
             Arr::except($chuck->toArray(), 'updated_at'),
             Arr::except($john->grandsons->first()->toArray(), 'updated_at')
@@ -140,7 +152,10 @@ final class EmbedsManyRelationTest extends IntegrationTestCase
         $this->assertTrue($john->update());
         $john = $john->first($john->_id);
 
-        $this->assertInstanceOf(EmbeddedUser::class, $john->grandsons->first());
+        $this->assertInstanceOf(
+            EmbeddedUser::class,
+            $john->grandsons->first()
+        );
         $this->assertEquals(
             Arr::except($chuck->toArray(), 'updated_at'),
             Arr::except($john->grandsons->first()->toArray(), 'updated_at')

--- a/tests/Integration/EmbedsOneRelationTest.php
+++ b/tests/Integration/EmbedsOneRelationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use MongoDB\BSON\ObjectId;
@@ -112,7 +113,9 @@ final class EmbedsOneRelationTest extends IntegrationTestCase
 
         // Expectations
         $this->expectException(InvalidFieldNameException::class);
-        $this->expectExceptionMessage('The field for relation "sameName" cannot have the same name as the relation');
+        $this->expectExceptionMessage(
+            'The field for relation "sameName" cannot have the same name as the relation'
+        );
 
         // Actions
         $user->sameName;

--- a/tests/Integration/EntityAssemblerTest.php
+++ b/tests/Integration/EntityAssemblerTest.php
@@ -15,6 +15,7 @@ class EntityAssemblerTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
+
         m::close();
     }
 
@@ -31,7 +32,7 @@ class EntityAssemblerTest extends TestCase
         $entityAssembler = new EntityAssembler();
         $schemas = [];
         foreach ($availableSchemas as $key => $value) {
-            $schemas[$key] = m::mock(Schema::class.'[]');
+            $schemas[$key] = m::mock(Schema::class . '[]');
             $schemas[$key]->entityClass = $value['entityClass'];
             $schemas[$key]->fields = $value['fields'];
         }
@@ -42,7 +43,10 @@ class EntityAssemblerTest extends TestCase
         }
 
         // Assert
-        $result = $entityAssembler->assemble($inputValue, $schemas[$inputSchema]);
+        $result = $entityAssembler->assemble(
+            $inputValue,
+            $schemas[$inputSchema]
+        );
         $this->assertEquals($expectedOutput, $result);
     }
 
@@ -69,12 +73,14 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
-                'expectedOutput' => new LegacyRecordStudent([ // Expected output
-                    '_id' => new ObjectID('507f1f77bcf86cd799439011'),
-                    'name' => 'John Doe',
-                    'age' => 25,
-                    'grade' => 7.25,
-                ]),
+                'expectedOutput' => new LegacyRecordStudent(
+                    [ // Expected output
+                        '_id' => new ObjectID('507f1f77bcf86cd799439011'),
+                        'name' => 'John Doe',
+                        'age' => 25,
+                        'grade' => 7.25,
+                    ]
+                ),
             ],
 
             //---------------------------
@@ -108,13 +114,15 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
-                'expectedOutput' => new LegacyRecordStudent([ // Expected output
-                    '_id' => new ObjectID('507f1f77bcf86cd799439011'),
-                    'name' => 'John Doe',
-                    'age' => 25,
-                    'tests' => null,
-                    'finalGrade' => 7.25,
-                ]),
+                'expectedOutput' => new LegacyRecordStudent(
+                    [ // Expected output
+                        '_id' => new ObjectID('507f1f77bcf86cd799439011'),
+                        'name' => 'John Doe',
+                        'age' => 25,
+                        'tests' => null,
+                        'finalGrade' => 7.25,
+                    ]
+                ),
             ],
 
             //---------------------------
@@ -152,19 +160,23 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
-                'expectedOutput' => new LegacyRecordStudent([ // Expected output
-                    '_id' => new ObjectID('507f1f77bcf86cd799439011'),
-                    'name' => 'John Doe',
-                    'age' => 25,
-                    'tests' => [
-                        new LegacyRecordStudent([
-                            '_id' => new ObjectID('507f1f77bcf86cd7994390ea'),
-                            'subject' => 'math',
-                            'grade' => 7.25,
-                        ]),
-                    ],
-                    'finalGrade' => 7.25,
-                ]),
+                'expectedOutput' => new LegacyRecordStudent(
+                    [ // Expected output
+                        '_id' => new ObjectID('507f1f77bcf86cd799439011'),
+                        'name' => 'John Doe',
+                        'age' => 25,
+                        'tests' => [
+                            new LegacyRecordStudent([
+                                '_id' => new ObjectID(
+                                    '507f1f77bcf86cd7994390ea'
+                                ),
+                                'subject' => 'math',
+                                'grade' => 7.25,
+                            ]),
+                        ],
+                        'finalGrade' => 7.25,
+                    ]
+                ),
             ],
 
             //---------------------------
@@ -209,24 +221,30 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
-                'expectedOutput' => new LegacyRecordStudent([ // Expected output
-                    '_id' => new ObjectID('507f1f77bcf86cd799439011'),
-                    'name' => 'John Doe',
-                    'age' => 25,
-                    'tests' => [
-                        new LegacyRecordStudent([
-                            '_id' => new ObjectID('507f1f77bcf86cd7994390ea'),
-                            'subject' => 'math',
-                            'grade' => 7.25,
-                        ]),
-                        new LegacyRecordStudent([
-                            '_id' => new ObjectID('507f1f77bcf86cd7994390eb'),
-                            'subject' => 'english',
-                            'grade' => 9.0,
-                        ]),
-                    ],
-                    'finalGrade' => 7.25,
-                ]),
+                'expectedOutput' => new LegacyRecordStudent(
+                    [ // Expected output
+                        '_id' => new ObjectID('507f1f77bcf86cd799439011'),
+                        'name' => 'John Doe',
+                        'age' => 25,
+                        'tests' => [
+                            new LegacyRecordStudent([
+                                '_id' => new ObjectID(
+                                    '507f1f77bcf86cd7994390ea'
+                                ),
+                                'subject' => 'math',
+                                'grade' => 7.25,
+                            ]),
+                            new LegacyRecordStudent([
+                                '_id' => new ObjectID(
+                                    '507f1f77bcf86cd7994390eb'
+                                ),
+                                'subject' => 'english',
+                                'grade' => 9.0,
+                            ]),
+                        ],
+                        'finalGrade' => 7.25,
+                    ]
+                ),
             ],
 
             //---------------------------
@@ -251,12 +269,14 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
-                'expectedOutput' => new LegacyRecordStudent([ // Expected output
-                    '_id' => new ObjectID('507f1f77bcf86cd799439011'),
-                    'name' => 'John Doe',
-                    'age' => 25,
-                    'grade' => 7.25,
-                ]),
+                'expectedOutput' => new LegacyRecordStudent(
+                    [ // Expected output
+                        '_id' => new ObjectID('507f1f77bcf86cd799439011'),
+                        'name' => 'John Doe',
+                        'age' => 25,
+                        'grade' => 7.25,
+                    ]
+                ),
             ],
         ];
     }

--- a/tests/Integration/EntityAssemblerTest.php
+++ b/tests/Integration/EntityAssemblerTest.php
@@ -73,8 +73,9 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
+                // Expected output
                 'expectedOutput' => new LegacyRecordStudent(
-                    [ // Expected output
+                    [
                         '_id' => new ObjectID('507f1f77bcf86cd799439011'),
                         'name' => 'John Doe',
                         'age' => 25,
@@ -114,8 +115,9 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
+                // Expected output
                 'expectedOutput' => new LegacyRecordStudent(
-                    [ // Expected output
+                    [
                         '_id' => new ObjectID('507f1f77bcf86cd799439011'),
                         'name' => 'John Doe',
                         'age' => 25,
@@ -160,8 +162,9 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
+                // Expected output
                 'expectedOutput' => new LegacyRecordStudent(
-                    [ // Expected output
+                    [
                         '_id' => new ObjectID('507f1f77bcf86cd799439011'),
                         'name' => 'John Doe',
                         'age' => 25,
@@ -221,8 +224,9 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
+                // Expected output
                 'expectedOutput' => new LegacyRecordStudent(
-                    [ // Expected output
+                    [
                         '_id' => new ObjectID('507f1f77bcf86cd799439011'),
                         'name' => 'John Doe',
                         'age' => 25,
@@ -269,8 +273,9 @@ class EntityAssemblerTest extends TestCase
                     ],
                 ],
                 'inputSchema' => 'studentSchema', // Schema that will be used to assembly $inputValue
+                // Expected output
                 'expectedOutput' => new LegacyRecordStudent(
-                    [ // Expected output
+                    [
                         '_id' => new ObjectID('507f1f77bcf86cd799439011'),
                         'name' => 'John Doe',
                         'age' => 25,

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use Mongolid\TestCase;
@@ -13,6 +14,7 @@ class IntegrationTestCase extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $host = getenv('DB_HOST') ?: 'localhost';
         $database = getenv('DB_DATABASE') ?: 'testing';
 
@@ -23,6 +25,7 @@ class IntegrationTestCase extends TestCase
     protected function tearDown(): void
     {
         $this->dropDatabase();
+
         parent::tearDown();
     }
 }

--- a/tests/Integration/LegacyRecordTest.php
+++ b/tests/Integration/LegacyRecordTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use MongoDB\BSON\ObjectId;
@@ -25,7 +26,10 @@ class LegacyRecordTest extends IntegrationTestCase
         $embedded->name = 'Embedded User';
         $entity->embed('siblings', $embedded);
 
-        $this->assertEquals('Embedded User', $entity->siblings()->first()->name);
+        $this->assertEquals(
+            'Embedded User',
+            $entity->siblings()->first()->name
+        );
     }
 
     public function testShouldFillModel(): void

--- a/tests/Integration/PersistLegacyModelWithSoftDeleteTest.php
+++ b/tests/Integration/PersistLegacyModelWithSoftDeleteTest.php
@@ -17,7 +17,9 @@ final class PersistLegacyModelWithSoftDeleteTest extends IntegrationTestCase
 
         // Actions
         $actualWhereResult = ProductWithSoftDelete::where()->first();
-        $actualFirstResult = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
+        $actualFirstResult = ProductWithSoftDelete::first(
+            '5bcb310783a7fcdf1bf1a672'
+        );
 
         // Assertions
         $this->assertEquals($product, $actualWhereResult);
@@ -32,7 +34,9 @@ final class PersistLegacyModelWithSoftDeleteTest extends IntegrationTestCase
 
         // Actions
         $actualWhereResult = ProductWithSoftDelete::where()->first();
-        $actualFirstResult = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
+        $actualFirstResult = ProductWithSoftDelete::first(
+            '5bcb310783a7fcdf1bf1a672'
+        );
 
         // Assertions
         $this->assertNull($actualWhereResult);
@@ -94,9 +98,9 @@ final class PersistLegacyModelWithSoftDeleteTest extends IntegrationTestCase
         $product = $this->persistProductWithSoftDeleteTrait();
 
         // Actions
-         $isDeleted = $product->delete();
-         $result = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
-         $deletedProduct = ProductWithSoftDelete::withTrashed()->first();
+        $isDeleted = $product->delete();
+        $result = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
+        $deletedProduct = ProductWithSoftDelete::withTrashed()->first();
 
         // Assertions
         $this->assertTrue($isDeleted);
@@ -117,8 +121,8 @@ final class PersistLegacyModelWithSoftDeleteTest extends IntegrationTestCase
         );
 
         // Actions
-         $isDeleted = $product->forceDelete();
-         $result = ProductWithSoftDelete::withTrashed();
+        $isDeleted = $product->forceDelete();
+        $result = ProductWithSoftDelete::withTrashed();
 
         // Assertions
         $this->assertTrue($isDeleted);
@@ -132,8 +136,8 @@ final class PersistLegacyModelWithSoftDeleteTest extends IntegrationTestCase
         $product = $this->persistProduct();
 
         // Actions
-         $isDeleted = $product->delete();
-         $result = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
+        $isDeleted = $product->delete();
+        $result = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
 
         // Assertions
         $this->assertTrue($isDeleted);

--- a/tests/Integration/PersistModelWithSoftDeleteTest.php
+++ b/tests/Integration/PersistModelWithSoftDeleteTest.php
@@ -2,7 +2,6 @@
 
 namespace Mongolid\Tests\Integration;
 
-use DateTime;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 use Mongolid\Model\ModelInterface;
@@ -20,7 +19,9 @@ final class PersistModelWithSoftDeleteTest extends IntegrationTestCase
 
         // Actions
         $actualWhereResult = ProductWithSoftDelete::where()->first();
-        $actualFirstResult = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
+        $actualFirstResult = ProductWithSoftDelete::first(
+            '5bcb310783a7fcdf1bf1a672'
+        );
 
         // Assertions
         $this->assertEquals($product, $actualWhereResult);
@@ -35,7 +36,9 @@ final class PersistModelWithSoftDeleteTest extends IntegrationTestCase
 
         // Actions
         $actualWhereResult = ProductWithSoftDelete::where()->first();
-        $actualFirstResult = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
+        $actualFirstResult = ProductWithSoftDelete::first(
+            '5bcb310783a7fcdf1bf1a672'
+        );
 
         // Assertions
         $this->assertNull($actualWhereResult);
@@ -97,8 +100,8 @@ final class PersistModelWithSoftDeleteTest extends IntegrationTestCase
         $product = $this->persistProductWithSoftDeleteTrait();
 
         // Actions
-         $isDeleted = $product->delete();
-         $result = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
+        $isDeleted = $product->delete();
+        $result = ProductWithSoftDelete::first('5bcb310783a7fcdf1bf1a672');
 
         // Assertions
         $this->assertTrue($isDeleted);
@@ -113,11 +116,13 @@ final class PersistModelWithSoftDeleteTest extends IntegrationTestCase
     {
         // Set
         $product = $this->persistProductWithSoftDeleteTrait();
-        $product2 = $this->persistProductWithSoftDeleteTrait('5bcb310783a7fcdf1bf1a123');
+        $product2 = $this->persistProductWithSoftDeleteTrait(
+            '5bcb310783a7fcdf1bf1a123'
+        );
 
         // Actions
-         $isDeleted = $product->forceDelete();
-         $result = ProductWithSoftDelete::withTrashed();
+        $isDeleted = $product->forceDelete();
+        $result = ProductWithSoftDelete::withTrashed();
 
         // Assertions
         $this->assertTrue($isDeleted);
@@ -131,8 +136,8 @@ final class PersistModelWithSoftDeleteTest extends IntegrationTestCase
         $product = $this->persistProduct();
 
         // Actions
-         $isDeleted = $product->delete();
-         $result = ProductWithSoftDelete::first($this->_id);
+        $isDeleted = $product->delete();
+        $result = ProductWithSoftDelete::first($this->_id);
 
         // Assertions
         $this->assertTrue($isDeleted);

--- a/tests/Integration/PersistedDataTest.php
+++ b/tests/Integration/PersistedDataTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use MongoDB\BSON\ObjectId;
@@ -6,16 +7,7 @@ use Mongolid\Tests\Stubs\ReferencedUser;
 
 final class PersistedDataTest extends IntegrationTestCase
 {
-    /**
-     * @var ObjectId
-     */
-    private $_id;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->_id = new ObjectId('5bcb310783a7fcdf1bf1a672');
-    }
+    private ObjectId $_id;
 
     public function testSaveInsertingData(): void
     {
@@ -148,6 +140,13 @@ final class PersistedDataTest extends IntegrationTestCase
          * In this test, User must have his old name after refresh because its model wasn't persisted after setting its name to Jane Doe.
          */
         $this->assertSame('John Doe', $result->name);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->_id = new ObjectId('5bcb310783a7fcdf1bf1a672');
     }
 
     private function getUser(bool $save = false): ReferencedUser

--- a/tests/Integration/ReferencesManyRelationTest.php
+++ b/tests/Integration/ReferencesManyRelationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use MongoDB\BSON\ObjectId;
@@ -60,7 +61,11 @@ final class ReferencesManyRelationTest extends IntegrationTestCase
         // changing the field with fillable
         $john->siblings()->attach($bob);
         $this->assertSiblings([$bob], $john);
-        $john = ReferencedUser::fill(['siblings_ids' => [$chuck->_id]], $john, true);
+        $john = ReferencedUser::fill(
+            ['siblings_ids' => [$chuck->_id]],
+            $john,
+            true
+        );
         $this->assertSiblings([$chuck], $john);
 
         // detach not attached has no problems
@@ -126,11 +131,15 @@ final class ReferencesManyRelationTest extends IntegrationTestCase
         // changing the field with fillable
         $john->grandsons()->attach($bob);
         $this->assertGrandsons([$bob], $john);
-        $john = ReferencedUser::fill(['grandsons_codes' => [$chuck->code]], $john, true);
+        $john = ReferencedUser::fill(
+            ['grandsons_codes' => [$chuck->code]],
+            $john,
+            true
+        );
         $this->assertGrandsons([$chuck], $john);
     }
 
-    private function createUser(string $name, string $code = null): ReferencedUser
+    private function createUser(string $name, ?string $code = null): ReferencedUser
     {
         $user = new ReferencedUser();
         $user->_id = new ObjectId();

--- a/tests/Integration/ReferencesOneRelationTest.php
+++ b/tests/Integration/ReferencesOneRelationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use MongoDB\BSON\ObjectId;
@@ -51,7 +52,11 @@ final class ReferencesOneRelationTest extends IntegrationTestCase
         // changing the field with fillable
         $john->parent()->attach($bob);
         $this->assertParent($bob, $john);
-        $john = ReferencedUser::fill(['parent_id' => $chuck->_id], $john, true);
+        $john = ReferencedUser::fill(
+            ['parent_id' => $chuck->_id],
+            $john,
+            true
+        );
         $this->assertParent($chuck, $john);
     }
 
@@ -99,7 +104,11 @@ final class ReferencesOneRelationTest extends IntegrationTestCase
         // changing the field with fillable
         $john->son()->attach($bob);
         $this->assertSon($bob, $john);
-        $john = ReferencedUser::fill(['arbitrary_field' => $chuck->code], $john, true);
+        $john = ReferencedUser::fill(
+            ['arbitrary_field' => $chuck->code],
+            $john,
+            true
+        );
         $this->assertSon($chuck, $john);
     }
 
@@ -110,13 +119,15 @@ final class ReferencesOneRelationTest extends IntegrationTestCase
 
         // Expectations
         $this->expectException(NotARelationException::class);
-        $this->expectExceptionMessage('Called method "invalid" is not a Relation!');
+        $this->expectExceptionMessage(
+            'Called method "invalid" is not a Relation!'
+        );
 
         // Actions
         $user->invalid;
     }
 
-    private function createUser(string $name, string $code = null): ReferencedUser
+    private function createUser(string $name, ?string $code = null): ReferencedUser
     {
         $user = new ReferencedUser();
         $user->_id = new ObjectId();

--- a/tests/Integration/RewindableCursorTest.php
+++ b/tests/Integration/RewindableCursorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Integration;
 
 use MongoDB\BSON\ObjectId;


### PR DESCRIPTION
This PR is the eighth in a series of PRs aimed at adding coding standards to Mongolid (the PR "https://github.com/leroy-merlin-br/mongolid/pull/247" is being split, and this is the fifth part, related to the Integration Tests context).

The additions made here are being split from the PR: 
https://github.com/leroy-merlin-br/mongolid/pull/209/files#diff-44c6c764ba381928e3221e4690c18dc0fe596311af5b123d5d2089ffc4db52af

And are tested in the project: https://github.com/JoaoFerrazfs/Mongo-PHP-Docker_BaseProject