### PR TITLE
refactor: changed types and annotations for Tests Stubs context

### DIFF
--- a/tests/Stubs/EmbeddedUser.php
+++ b/tests/Stubs/EmbeddedUser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;

--- a/tests/Stubs/ExpirablePrice.php
+++ b/tests/Stubs/ExpirablePrice.php
@@ -2,8 +2,6 @@
 
 namespace Mongolid\Tests\Stubs;
 
-use DateTime;
-
 class ExpirablePrice extends Price
 {
     protected array $casts = [

--- a/tests/Stubs/Legacy/LegacyRecordUser.php
+++ b/tests/Stubs/Legacy/LegacyRecordUser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs\Legacy;
 
 use Mongolid\Cursor\CursorInterface;
@@ -6,16 +7,13 @@ use Mongolid\LegacyRecord;
 
 class LegacyRecordUser extends LegacyRecord
 {
-    protected ?string $collection = 'users';
-
     public bool $mutable = true;
 
-    /**
-     * @var bool
-     */
-    protected $timestamps = true;
-
     public bool $dynamic = false;
+
+    protected ?string $collection = 'users';
+
+    protected bool $timestamps = true;
 
     protected array $fillable = [
         'name',

--- a/tests/Stubs/Legacy/Product.php
+++ b/tests/Stubs/Legacy/Product.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs\Legacy;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -8,18 +9,18 @@ use Mongolid\Tests\Stubs\Price;
 
 class Product extends LegacyRecord
 {
-    protected ?string $collection = 'products';
-
     public array $with = [
         'price' => [
             'key' => '_id',
-            'model' => Price::class
+            'model' => Price::class,
         ],
         'shop' => [
             'key' => 'skus.shop_id',
             'model' => Shop::class,
         ],
     ];
+
+    protected ?string $collection = 'products';
 
     /**
      * @throws BindingResolutionException

--- a/tests/Stubs/Legacy/Shop.php
+++ b/tests/Stubs/Legacy/Shop.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs\Legacy;
 
 use Mongolid\LegacyRecord;

--- a/tests/Stubs/Legacy/Sku.php
+++ b/tests/Stubs/Legacy/Sku.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs\Legacy;
 
 use Illuminate\Contracts\Container\BindingResolutionException;

--- a/tests/Stubs/PolymorphedReferencedUser.php
+++ b/tests/Stubs/PolymorphedReferencedUser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 class PolymorphedReferencedUser extends ReferencedUser

--- a/tests/Stubs/Price.php
+++ b/tests/Stubs/Price.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;

--- a/tests/Stubs/Product.php
+++ b/tests/Stubs/Product.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;

--- a/tests/Stubs/ReferencedUser.php
+++ b/tests/Stubs/ReferencedUser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use Mongolid\Model\AbstractModel;
@@ -30,7 +31,11 @@ class ReferencedUser extends AbstractModel implements PolymorphableModelInterfac
 
     public function son(): ReferencesOne
     {
-        return $this->referencesOne(ReferencedUser::class, 'arbitrary_field', 'code');
+        return $this->referencesOne(
+            ReferencedUser::class,
+            'arbitrary_field',
+            'code'
+        );
     }
 
     public function grandsons(): ReferencesMany

--- a/tests/Stubs/ReplaceCollectionModel.php
+++ b/tests/Stubs/ReplaceCollectionModel.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Tests\Stubs;
 
 use MongoDB\Collection;


### PR DESCRIPTION
This PR is the ninth in a series of PRs aimed at adding coding standards to Mongolid (the PR "https://github.com/leroy-merlin-br/mongolid/pull/247" is being split, and this is the sixth part, related to the Stubs context).

The additions made here are being split from the PR: 
https://github.com/leroy-merlin-br/mongolid/pull/209/files#diff-44c6c764ba381928e3221e4690c18dc0fe596311af5b123d5d2089ffc4db52af

And are tested in the project: https://github.com/JoaoFerrazfs/Mongo-PHP-Docker_BaseProject