### PR TITLE
refactor: changed types and annotations for Unit tests context

### DIFF
--- a/tests/Unit/Cursor/CursorTest.php
+++ b/tests/Unit/Cursor/CursorTest.php
@@ -2,7 +2,6 @@
 
 namespace Mongolid\Cursor;
 
-use ArrayIterator;
 use ArrayObject;
 use Exception;
 use Iterator;
@@ -11,7 +10,6 @@ use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Database;
 use MongoDB\Driver\Exception\LogicException;
-use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Model\CachingIterator;
 use Mongolid\Connection\Connection;

--- a/tests/Unit/Cursor/SchemaCursorTest.php
+++ b/tests/Unit/Cursor/SchemaCursorTest.php
@@ -11,7 +11,6 @@ use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Database;
 use MongoDB\Driver\Exception\LogicException;
-use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadPreference;
 use Mongolid\Connection\Connection;
 use Mongolid\LegacyRecord;

--- a/tests/Unit/DataMapper/DataMapperTest.php
+++ b/tests/Unit/DataMapper/DataMapperTest.php
@@ -26,7 +26,9 @@ class DataMapperTest extends TestCase
     public function tearDown(): void
     {
         unset($this->eventService);
+
         parent::tearDown();
+
         m::close();
     }
 
@@ -37,7 +39,10 @@ class DataMapperTest extends TestCase
     {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
         $options = ['writeConcern' => new WriteConcern($writeConcern)];
 
         $collection = m::mock(Collection::class);
@@ -63,7 +68,12 @@ class DataMapperTest extends TestCase
             ->with(
                 ['_id' => 123],
                 $parsedObject,
-                ['upsert' => true, 'writeConcern' => new WriteConcern($writeConcern)]
+                [
+                    'upsert' => true,
+                    'writeConcern' => new WriteConcern(
+                        $writeConcern
+                    ),
+                ]
             )->andReturn($operationResult);
 
         $operationResult->shouldReceive('isAcknowledged')
@@ -94,11 +104,18 @@ class DataMapperTest extends TestCase
     /**
      * @dataProvider getWriteConcernVariations
      */
-    public function testShouldInsert(object $entity, int $writeConcern, bool $shouldFireEventAfter, bool $expected): void
-    {
+    public function testShouldInsert(
+        object $entity,
+        int $writeConcern,
+        bool $shouldFireEventAfter,
+        bool $expected
+    ): void {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
         $options = ['writeConcern' => new WriteConcern($writeConcern)];
 
         $collection = m::mock(Collection::class);
@@ -121,7 +138,10 @@ class DataMapperTest extends TestCase
 
         $collection->shouldReceive('insertOne')
             ->once()
-            ->with($parsedObject, ['writeConcern' => new WriteConcern($writeConcern)])
+            ->with(
+                $parsedObject,
+                ['writeConcern' => new WriteConcern($writeConcern)]
+            )
             ->andReturn($operationResult);
 
         $operationResult->shouldReceive('isAcknowledged')
@@ -152,11 +172,18 @@ class DataMapperTest extends TestCase
     /**
      * @dataProvider getWriteConcernVariations
      */
-    public function testShouldInsertWithoutFiringEvents(object $entity, int $writeConcern, bool $shouldFireEventAfter, bool $expected): void
-    {
+    public function testShouldInsertWithoutFiringEvents(
+        object $entity,
+        int $writeConcern,
+        bool $shouldFireEventAfter,
+        bool $expected
+    ): void {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
         $options = ['writeConcern' => new WriteConcern($writeConcern)];
 
         $collection = m::mock(Collection::class);
@@ -179,7 +206,10 @@ class DataMapperTest extends TestCase
 
         $collection->shouldReceive('insertOne')
             ->once()
-            ->with($parsedObject, ['writeConcern' => new WriteConcern($writeConcern)])
+            ->with(
+                $parsedObject,
+                ['writeConcern' => new WriteConcern($writeConcern)]
+            )
             ->andReturn($operationResult);
 
         $operationResult->shouldReceive('isAcknowledged')
@@ -199,17 +229,27 @@ class DataMapperTest extends TestCase
         $this->expectEventNotToBeFired('inserted', $entity);
 
         // Assert
-        $this->assertEquals($expected, $mapper->insert($entity, $options, false));
+        $this->assertEquals(
+            $expected,
+            $mapper->insert($entity, $options, false)
+        );
     }
 
     /**
      * @dataProvider getWriteConcernVariations
      */
-    public function testShouldUpdate(object $entity, int $writeConcern, bool $shouldFireEventAfter, bool $expected): void
-    {
+    public function testShouldUpdate(
+        object $entity,
+        int $writeConcern,
+        bool $shouldFireEventAfter,
+        bool $expected
+    ): void {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
 
         $collection = m::mock(Collection::class);
         $parsedObject = ['_id' => 123];
@@ -273,7 +313,10 @@ class DataMapperTest extends TestCase
         // Arrange
         $entity = m::mock(ModelInterface::class);
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
 
         $collection = m::mock(Collection::class);
         $operationResult = m::mock();
@@ -366,7 +409,10 @@ class DataMapperTest extends TestCase
         // Arrange
         $entity = m::mock(ModelInterface::class);
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
 
         $collection = m::mock(Collection::class);
         $operationResult = m::mock();
@@ -422,7 +468,7 @@ class DataMapperTest extends TestCase
             '$pull' => [
                 'hobbies' => null,
                 'nested.null-values' => null,
-            ]
+            ],
         ];
 
         // Act
@@ -481,7 +527,10 @@ class DataMapperTest extends TestCase
         // Arrange
         $entity = m::mock(ModelInterface::class);
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
 
         $options = ['writeConcern' => new WriteConcern(1)];
 
@@ -530,7 +579,10 @@ class DataMapperTest extends TestCase
     ): void {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
 
         $collection = m::mock(Collection::class);
         $parsedObject = ['_id' => 123];
@@ -589,11 +641,18 @@ class DataMapperTest extends TestCase
     /**
      * @dataProvider getWriteConcernVariations
      */
-    public function testShouldDelete(object $entity, int $writeConcern, bool $shouldFireEventAfter, bool $expected): void
-    {
+    public function testShouldDelete(
+        object $entity,
+        int $writeConcern,
+        bool $shouldFireEventAfter,
+        bool $expected
+    ): void {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class . '[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
 
         $collection = m::mock(Collection::class);
         $parsedObject = ['_id' => 123];
@@ -616,12 +675,15 @@ class DataMapperTest extends TestCase
 
         $collection->shouldReceive('deleteOne')
             ->once()
-            ->with(['_id' => 123], ['writeConcern' => new WriteConcern($writeConcern)])
+            ->with(
+                ['_id' => 123],
+                ['writeConcern' => new WriteConcern($writeConcern)]
+            )
             ->andReturn($operationResult);
 
         $operationResult->shouldReceive('isAcknowledged')
             ->once()
-            ->andReturn((bool)$writeConcern);
+            ->andReturn((bool) $writeConcern);
 
         $operationResult->shouldReceive('getDeletedCount')
             ->andReturn(1);
@@ -654,7 +716,10 @@ class DataMapperTest extends TestCase
     ): void {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class . '[parseToDocument,getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[parseToDocument,getCollection]',
+            [$connection]
+        );
         $collection = m::mock(Collection::class);
         $entity = m::mock(ModelInterface::class);
 
@@ -685,7 +750,10 @@ class DataMapperTest extends TestCase
     {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[getCollection]',
+            [$connection]
+        );
         $schema = m::mock(Schema::class);
 
         $collection = m::mock(Collection::class);
@@ -714,7 +782,10 @@ class DataMapperTest extends TestCase
         $this->assertEquals($schema, $result->entitySchema);
         $this->assertSame($preparedQuery, $result->params()[0]);
 
-        $this->assertInstanceOf(SchemaCacheableCursor::class, $cacheableResult);
+        $this->assertInstanceOf(
+            SchemaCacheableCursor::class,
+            $cacheableResult
+        );
         $this->assertEquals($schema, $cacheableResult->entitySchema);
     }
 
@@ -722,7 +793,7 @@ class DataMapperTest extends TestCase
     {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[where]', [$connection]);
+        $mapper = m::mock(DataMapper::class . '[where]', [$connection]);
         $mongolidCursor = m::mock(SchemaCursor::class);
 
         // Expect
@@ -742,7 +813,10 @@ class DataMapperTest extends TestCase
     {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[getCollection]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[getCollection]',
+            [$connection]
+        );
         $schema = m::mock(Schema::class);
 
         $collection = m::mock(Collection::class);
@@ -779,7 +853,7 @@ class DataMapperTest extends TestCase
         // Arrange
         $connection = m::mock(Connection::class);
         $mapper = m::mock(
-            DataMapper::class.'[prepareValueQuery,getCollection]',
+            DataMapper::class . '[prepareValueQuery,getCollection]',
             [$connection]
         );
         $schema = m::mock(Schema::class);
@@ -817,7 +891,7 @@ class DataMapperTest extends TestCase
     {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[where]', [$connection]);
+        $mapper = m::mock(DataMapper::class . '[where]', [$connection]);
         $query = 123;
         $entity = new stdClass();
         $cursor = m::mock(SchemaCacheableCursor::class);
@@ -843,7 +917,7 @@ class DataMapperTest extends TestCase
     {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[where]', [$connection]);
+        $mapper = m::mock(DataMapper::class . '[where]', [$connection]);
         $query = 123;
         $entity = new stdClass();
         $cursor = m::mock(SchemaCacheableCursor::class);
@@ -870,10 +944,16 @@ class DataMapperTest extends TestCase
     {
         // Arrange
         $connection = m::mock(Connection::class);
-        $mapper = m::mock(DataMapper::class.'[getSchemaMapper]', [$connection]);
+        $mapper = m::mock(
+            DataMapper::class . '[getSchemaMapper]',
+            [$connection]
+        );
         $entity = m::mock();
         $parsedDocument = ['a_field' => 123, '_id' => 'bacon'];
-        $schemaMapper = m::mock(SchemaMapper::class.'[]', [m::mock(Schema::class)]);
+        $schemaMapper = m::mock(
+            SchemaMapper::class . '[]',
+            [m::mock(Schema::class)]
+        );
 
         $mapper->shouldAllowMockingProtectedMethods();
 
@@ -973,40 +1053,12 @@ class DataMapperTest extends TestCase
         $data = ['valid' => true, 'invalid-key' => 'invalid-value'];
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid projection: 'invalid-key' => 'invalid-value'");
+        $this->expectExceptionMessage(
+            "Invalid projection: 'invalid-key' => 'invalid-value'"
+        );
 
         // Act
         $this->callProtected($mapper, 'prepareProjection', [$data]);
-    }
-
-    protected function getEventService(): m\MockInterface
-    {
-        if (!$this->eventService) {
-            $this->eventService = m::mock(EventTriggerService::class);
-            Container::instance(EventTriggerService::class, $this->eventService);
-        }
-
-        return $this->eventService;
-    }
-
-    protected function expectEventToBeFired(string $event, object $entity, bool $halt, bool $return = true): void
-    {
-        $event = 'mongolid.'.$event.': '.get_class($entity);
-
-        $this->getEventService()->shouldReceive('fire')
-            ->with($event, $entity, $halt)
-            ->atLeast()
-            ->once()
-            ->andReturn($return);
-    }
-
-    protected function expectEventNotToBeFired(string $event, object $entity): void
-    {
-        $event = 'mongolid.'.$event.': '.get_class($entity);
-
-        $this->getEventService()->shouldReceive('fire')
-            ->with($event, $entity, m::any())
-            ->never();
     }
 
     public function eventsToBailOperations(): array
@@ -1091,5 +1143,38 @@ class DataMapperTest extends TestCase
                 'expected' => ['some' => false, 'fields' => true],
             ],
         ];
+    }
+
+    protected function getEventService(): m\MockInterface
+    {
+        if (!$this->eventService) {
+            $this->eventService = m::mock(EventTriggerService::class);
+            Container::instance(
+                EventTriggerService::class,
+                $this->eventService
+            );
+        }
+
+        return $this->eventService;
+    }
+
+    protected function expectEventToBeFired(string $event, object $entity, bool $halt, bool $return = true): void
+    {
+        $event = 'mongolid.' . $event . ': ' . $entity::class;
+
+        $this->getEventService()->shouldReceive('fire')
+            ->with($event, $entity, $halt)
+            ->atLeast()
+            ->once()
+            ->andReturn($return);
+    }
+
+    protected function expectEventNotToBeFired(string $event, object $entity): void
+    {
+        $event = 'mongolid.' . $event . ': ' . $entity::class;
+
+        $this->getEventService()->shouldReceive('fire')
+            ->with($event, $entity, m::any())
+            ->never();
     }
 }

--- a/tests/Unit/DataMapper/SchemaMapperTest.php
+++ b/tests/Unit/DataMapper/SchemaMapperTest.php
@@ -6,12 +6,14 @@ use Mockery as m;
 use Mongolid\Container\Container;
 use Mongolid\Schema\Schema;
 use Mongolid\TestCase;
+use Mockery\LegacyMockInterface;
 
 class SchemaMapperTest extends TestCase
 {
     public function tearDown(): void
     {
         parent::tearDown();
+
         m::close();
     }
 
@@ -25,7 +27,7 @@ class SchemaMapperTest extends TestCase
             'stuff' => 'schema.My\Own\Schema',
         ];
         $schemaMapper = m::mock(
-            SchemaMapper::class.'[clearDynamic,parseField]',
+            SchemaMapper::class . '[clearDynamic,parseField]',
             [$schema]
         );
         $schemaMapper->shouldAllowMockingProtectedMethods();
@@ -44,7 +46,7 @@ class SchemaMapperTest extends TestCase
             $schemaMapper->shouldReceive('parseField')
                 ->once()
                 ->with($data[$key], $value)
-                ->andReturn($data[$key].'.PARSED');
+                ->andReturn($data[$key] . '.PARSED');
         }
 
         // Assert
@@ -136,7 +138,7 @@ class SchemaMapperTest extends TestCase
         // Arrange
         $schema = m::mock(Schema::class);
         $schemaMapper = m::mock(
-            SchemaMapper::class.'[mapToSchema]',
+            SchemaMapper::class . '[mapToSchema]',
             [$schema]
         );
         $schemaMapper->shouldAllowMockingProtectedMethods();
@@ -157,7 +159,7 @@ class SchemaMapperTest extends TestCase
     public function testShouldParseFieldUsingAMethodInSchemaIfTypeIsAnUnknownString(): void
     {
         // Arrange
-        $schemaClass = new class() extends Schema {
+        $schemaClass = new class () extends Schema {
             public function pumpkinPoint($value)
             {
                 return $value * 2;
@@ -187,28 +189,38 @@ class SchemaMapperTest extends TestCase
         Container::instance('Xd\MySchema', $mySchema);
 
         // When instantiating the SchemaMapper with the specified $param as dependency
-        Container::bind(SchemaMapper::class, function ($container, $params) use ($value, $mySchema, $test): \Mockery\LegacyMockInterface {
-            // Check if mySchema has been injected correctly
-            $test->assertSame($mySchema, $params['schema']);
+        Container::bind(
+            SchemaMapper::class,
+            function ($container, $params) use ($value, $mySchema, $test): LegacyMockInterface {
+                // Check if mySchema has been injected correctly
+                $test->assertSame($mySchema, $params['schema']);
 
-            // Instantiate a SchemaMapper with mySchema
-            $anotherSchemaMapper = m::mock(SchemaMapper::class, [$params['schema']]);
+                // Instantiate a SchemaMapper with mySchema
+                $anotherSchemaMapper = m::mock(
+                    SchemaMapper::class,
+                    [$params['schema']]
+                );
 
-            // Set expectation to receive a map call
-            $anotherSchemaMapper->shouldReceive('map')
-                ->once()
-                ->with($value)
-                ->andReturn(['foo' => 'PARSED']);
+                // Set expectation to receive a map call
+                $anotherSchemaMapper->shouldReceive('map')
+                    ->once()
+                    ->with($value)
+                    ->andReturn(['foo' => 'PARSED']);
 
-            return $anotherSchemaMapper;
-        });
+                return $anotherSchemaMapper;
+            }
+        );
 
         // Assert
         $this->assertEquals(
             [
                 ['foo' => 'PARSED'],
             ],
-            $this->callProtected($schemaMapper, 'mapToSchema', [$value, 'Xd\MySchema'])
+            $this->callProtected(
+                $schemaMapper,
+                'mapToSchema',
+                [$value, 'Xd\MySchema']
+            )
         );
     }
 
@@ -245,7 +257,7 @@ class SchemaMapperTest extends TestCase
         // Arrange
         $schema = m::mock(Schema::class);
         $schemaMapper = new SchemaMapper($schema);
-        $object = new class() {
+        $object = new class () {
             /**
              * @return array{foo: string}
              */

--- a/tests/Unit/LegacyRecordTest.php
+++ b/tests/Unit/LegacyRecordTest.php
@@ -21,7 +21,8 @@ class LegacyRecordTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->entity = new class() extends LegacyRecord {
+
+        $this->entity = new class () extends LegacyRecord {
             protected ?string $collection = 'legacy_record';
         };
     }
@@ -32,6 +33,7 @@ class LegacyRecordTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
+
         m::close();
         unset($this->entity);
     }
@@ -48,7 +50,9 @@ class LegacyRecordTest extends TestCase
     public function testShouldSave(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper,getCollectionName,syncOriginalAttributes]');
+        $entity = m::mock(
+            LegacyRecord::class . '[getDataMapper,getCollectionName,syncOriginalAttributes]'
+        );
         $dataMapper = m::mock();
 
         // Act
@@ -73,7 +77,9 @@ class LegacyRecordTest extends TestCase
     public function testShouldInsert(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper,getCollectionName,syncOriginalAttributes]');
+        $entity = m::mock(
+            LegacyRecord::class . '[getDataMapper,getCollectionName,syncOriginalAttributes]'
+        );
         $dataMapper = m::mock();
 
         // Act
@@ -98,7 +104,9 @@ class LegacyRecordTest extends TestCase
     public function testShouldUpdate(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper,getCollectionName,syncOriginalAttributes]');
+        $entity = m::mock(
+            LegacyRecord::class . '[getDataMapper,getCollectionName,syncOriginalAttributes]'
+        );
         $dataMapper = m::mock();
 
         // Act
@@ -123,7 +131,9 @@ class LegacyRecordTest extends TestCase
     public function testShouldDelete(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper,getCollectionName]');
+        $entity = m::mock(
+            LegacyRecord::class . '[getDataMapper,getCollectionName]'
+        );
         $dataMapper = m::mock();
 
         // Act
@@ -145,7 +155,7 @@ class LegacyRecordTest extends TestCase
     public function testShouldGetWithWhereQuery(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper]');
+        $entity = m::mock(LegacyRecord::class . '[getDataMapper]');
         $this->setProtected($entity, 'collection', 'mongolid');
         $query = ['foo' => 'bar'];
         $projection = ['some', 'fields'];
@@ -164,13 +174,16 @@ class LegacyRecordTest extends TestCase
             ->andReturn($cursor);
 
         // Assert
-        $this->assertEquals($cursor, $entity->where($query, $projection, true));
+        $this->assertEquals(
+            $cursor,
+            $entity->where($query, $projection, true)
+        );
     }
 
     public function testShouldGetAll(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper]');
+        $entity = m::mock(LegacyRecord::class . '[getDataMapper]');
         $this->setProtected($entity, 'collection', 'mongolid');
         $dataMapper = m::mock();
         $cursor = m::mock(CursorInterface::class);
@@ -192,7 +205,7 @@ class LegacyRecordTest extends TestCase
     public function testShouldGetFirstWithQuery(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper]');
+        $entity = m::mock(LegacyRecord::class . '[getDataMapper]');
         $this->setProtected($entity, 'collection', 'mongolid');
         $query = ['foo' => 'bar'];
         $projection = ['some', 'fields'];
@@ -210,13 +223,16 @@ class LegacyRecordTest extends TestCase
             ->andReturn($entity);
 
         // Assert
-        $this->assertEquals($entity, $entity->first($query, $projection, true));
+        $this->assertEquals(
+            $entity,
+            $entity->first($query, $projection, true)
+        );
     }
 
     public function testShouldGetFirstOrFail(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper]');
+        $entity = m::mock(LegacyRecord::class . '[getDataMapper]');
         $this->setProtected($entity, 'collection', 'mongolid');
         $query = ['foo' => 'bar'];
         $projection = ['some', 'fields'];
@@ -234,13 +250,16 @@ class LegacyRecordTest extends TestCase
             ->andReturn($entity);
 
         // Assert
-        $this->assertEquals($entity, $entity->firstOrFail($query, $projection, true));
+        $this->assertEquals(
+            $entity,
+            $entity->firstOrFail($query, $projection, true)
+        );
     }
 
     public function testShouldGetFirstOrNewAndReturnExistingModel(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper]');
+        $entity = m::mock(LegacyRecord::class . '[getDataMapper]');
         $this->setProtected($entity, 'collection', 'mongolid');
         $id = 123;
         $dataMapper = m::mock();
@@ -263,7 +282,7 @@ class LegacyRecordTest extends TestCase
     public function testShouldGetFirstOrNewAndReturnNewModel(): void
     {
         // Arrage
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper]');
+        $entity = m::mock(LegacyRecord::class . '[getDataMapper]');
         $this->setProtected($entity, 'collection', 'mongolid');
         $id = 123;
         $dataMapper = m::mock();
@@ -310,15 +329,18 @@ class LegacyRecordTest extends TestCase
         $this->assertInstanceOf(Schema::class, $result);
         $this->assertEquals($fields, $result->fields);
         $this->assertEquals($this->entity->dynamic, $result->dynamic);
-        $this->assertEquals($this->entity->getCollectionName(), $result->collection);
+        $this->assertEquals(
+            $this->entity->getCollectionName(),
+            $result->collection
+        );
         $this->assertEquals($this->entity::class, $result->entityClass);
     }
 
     public function testShouldGetDataMapper(): void
     {
         // Arrange
-        $entity = m::mock(LegacyRecord::class.'[getSchema]');
-        $schema = m::mock(Schema::class.'[]');
+        $entity = m::mock(LegacyRecord::class . '[getSchema]');
+        $schema = m::mock(Schema::class . '[]');
 
         // Act
         $entity->shouldAllowMockingProtectedMethods();
@@ -335,7 +357,7 @@ class LegacyRecordTest extends TestCase
 
     public function testShouldRaiseExceptionWhenHasNoCollectionAndTryToCallAllFunction(): void
     {
-        $entity = new class() extends LegacyRecord {
+        $entity = new class () extends LegacyRecord {
         };
 
         $this->expectException(NoCollectionNameException::class);
@@ -347,7 +369,7 @@ class LegacyRecordTest extends TestCase
 
     public function testShouldRaiseExceptionWhenHasNoCollectionAndTryToCallFirstFunction(): void
     {
-        $entity = new class() extends LegacyRecord {
+        $entity = new class () extends LegacyRecord {
         };
 
         $this->expectException(NoCollectionNameException::class);
@@ -359,7 +381,7 @@ class LegacyRecordTest extends TestCase
 
     public function testShouldRaiseExceptionWhenHasNoCollectionAndTryToCallWhereFunction(): void
     {
-        $entity = new class() extends LegacyRecord {
+        $entity = new class () extends LegacyRecord {
         };
 
         $this->expectException(NoCollectionNameException::class);
@@ -371,7 +393,7 @@ class LegacyRecordTest extends TestCase
 
     public function testShouldGetCollectionName(): void
     {
-        $entity = new class() extends LegacyRecord {
+        $entity = new class () extends LegacyRecord {
             protected ?string $collection = 'collection_name';
         };
 
@@ -380,7 +402,7 @@ class LegacyRecordTest extends TestCase
 
     public function testShouldAttachToAttribute(): void
     {
-        $entity = new class() extends LegacyRecord {
+        $entity = new class () extends LegacyRecord {
             protected ?string $collection = 'collection_name';
 
             public function class()
@@ -398,7 +420,7 @@ class LegacyRecordTest extends TestCase
 
     public function testShouldEmbedToAttribute(): void
     {
-        $entity = new class() extends LegacyRecord {
+        $entity = new class () extends LegacyRecord {
             protected ?string $collection = 'collection_name';
 
             public function classes()
@@ -410,12 +432,15 @@ class LegacyRecordTest extends TestCase
         $embedded->name = 'Course Class #1';
         $entity->embedToCourseClasses($embedded);
 
-        $this->assertEquals('Course Class #1', $entity->classes()->first()->name);
+        $this->assertEquals(
+            'Course Class #1',
+            $entity->classes()->first()->name
+        );
     }
 
     public function testShouldThrowBadMethodCallExceptionWhenCallingInvalidMethod(): void
     {
-        $entity = new class() extends LegacyRecord {
+        $entity = new class () extends LegacyRecord {
             protected ?string $collection = 'collection_name';
         };
 
@@ -436,7 +461,7 @@ class LegacyRecordTest extends TestCase
     {
         // Set
         $id = 'some-id-value';
-        $entity = m::mock(LegacyRecord::class.'[getDataMapper]');
+        $entity = m::mock(LegacyRecord::class . '[getDataMapper]');
         $this->setProtected($entity, 'collection', 'mongolid');
         $entity->_id = $id;
         $dataMapper = m::mock();
@@ -457,5 +482,4 @@ class LegacyRecordTest extends TestCase
         // Assertions
         $this->assertSame($entity, $result);
     }
-
 }

--- a/tests/Unit/Model/AbstractModelTest.php
+++ b/tests/Unit/Model/AbstractModelTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Mongolid\Model;
 
 use Mockery as m;
-use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Persistable;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -16,36 +16,7 @@ use stdClass;
 
 final class AbstractModelTest extends TestCase
 {
-    /**
-     * @var AbstractModel
-     */
-    protected $model;
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->model = new class() extends AbstractModel
-        {
-            protected ?string $collection = 'mongolid';
-
-            public function unsetCollection(): void
-            {
-                unset($this->collection);
-            }
-        };
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown(): void
-    {
-        unset($this->model);
-        parent::tearDown();
-    }
+    protected AbstractModel $model;
 
     public function testShouldImplementModelTraits(): void
     {
@@ -157,7 +128,9 @@ final class AbstractModelTest extends TestCase
 
         // Expectations
         $this->expectException(NoCollectionNameException::class);
-        $this->expectExceptionMessage('Collection name not specified into Model instance');
+        $this->expectExceptionMessage(
+            'Collection name not specified into Model instance'
+        );
 
         // Actions
         $this->model->save();
@@ -170,7 +143,9 @@ final class AbstractModelTest extends TestCase
 
         // Expectations
         $this->expectException(NoCollectionNameException::class);
-        $this->expectExceptionMessage('Collection name not specified into Model instance');
+        $this->expectExceptionMessage(
+            'Collection name not specified into Model instance'
+        );
 
         // Actions
         $this->model->update();
@@ -183,7 +158,9 @@ final class AbstractModelTest extends TestCase
 
         // Expectations
         $this->expectException(NoCollectionNameException::class);
-        $this->expectExceptionMessage('Collection name not specified into Model instance');
+        $this->expectExceptionMessage(
+            'Collection name not specified into Model instance'
+        );
 
         // Actions
         $this->model->insert();
@@ -196,7 +173,9 @@ final class AbstractModelTest extends TestCase
 
         // Expectations
         $this->expectException(NoCollectionNameException::class);
-        $this->expectExceptionMessage('Collection name not specified into Model instance');
+        $this->expectExceptionMessage(
+            'Collection name not specified into Model instance'
+        );
 
         // Actions
         $this->model->delete();
@@ -214,7 +193,12 @@ final class AbstractModelTest extends TestCase
         // Expectations
         $builder
             ->expects('where')
-            ->with(m::type(get_class($this->model)), $query, $projection, false)
+            ->with(
+                m::type(get_class($this->model)),
+                $query,
+                $projection,
+                false
+            )
             ->andReturn($cursor);
 
         // Actions
@@ -253,7 +237,12 @@ final class AbstractModelTest extends TestCase
         // Expectations
         $builder
             ->expects('first')
-            ->with(m::type(get_class($this->model)), $query, $projection, false)
+            ->with(
+                m::type(get_class($this->model)),
+                $query,
+                $projection,
+                false
+            )
             ->andReturn($this->model);
 
         // Actions
@@ -338,7 +327,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldRaiseExceptionWhenHasNoCollectionAndTryToCallAllFunction(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
 
@@ -352,7 +341,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldRaiseExceptionWhenHasNoCollectionAndTryToCallFirstFunction(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
 
@@ -366,7 +355,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldRaiseExceptionWhenHasNoCollectionAndTryToCallWhereFunction(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
 
@@ -408,7 +397,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldHaveDynamicSetters(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
 
@@ -434,10 +423,10 @@ final class AbstractModelTest extends TestCase
     public function testShouldHaveDynamicGetters(): void
     {
         // Set
-        $child = new class() extends AbstractModel
+        $child = new class () extends AbstractModel
         {
         };
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
 
@@ -461,7 +450,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldCheckIfAttributeIsSet(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
 
@@ -477,7 +466,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldCheckIfMutatedAttributeIsSet(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
             public bool $mutable = true;
 
@@ -495,7 +484,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldUnsetAttributes(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
         $model = $model::fill(
@@ -516,7 +505,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldGetAttributeFromMutator(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
             public bool $mutable = true;
 
@@ -537,7 +526,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldIgnoreMutators(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
             public function getShortNameDocumentAttribute(): string
             {
@@ -560,7 +549,7 @@ final class AbstractModelTest extends TestCase
     public function testShouldSetAttributeFromMutator(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
             protected bool $mutable = true;
 
@@ -587,7 +576,12 @@ final class AbstractModelTest extends TestCase
         // Expectations
         $builder
             ->expects('first')
-            ->with(m::type(get_class($this->model)), 'some-id-value', [], false)
+            ->with(
+                m::type(get_class($this->model)),
+                'some-id-value',
+                [],
+                false
+            )
             ->andReturn($this->model);
 
         // Actions
@@ -595,5 +589,33 @@ final class AbstractModelTest extends TestCase
 
         // Assertions
         $this->assertSame($this->model, $result);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->model = new class () extends AbstractModel
+        {
+            protected ?string $collection = 'mongolid';
+
+            public function unsetCollection(): void
+            {
+                unset($this->collection);
+            }
+        };
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        unset($this->model);
+
+        parent::tearDown();
     }
 }

--- a/tests/Unit/Model/Casts/CastResolverTest.php
+++ b/tests/Unit/Model/Casts/CastResolverTest.php
@@ -17,7 +17,10 @@ class CastResolverTest extends TestCase
 
         // Assertions
         $this->assertInstanceOf(DateTimeCast::class, $dateTimeCast);
-        $this->assertInstanceOf(ImmutableDateTimeCast::class, $dateTimeImmutableCast);
+        $this->assertInstanceOf(
+            ImmutableDateTimeCast::class,
+            $dateTimeImmutableCast
+        );
     }
 
     public function testShouldResolveFromCache(): void
@@ -35,7 +38,9 @@ class CastResolverTest extends TestCase
     {
         // Expectations
         $this->expectException(InvalidCastException::class);
-        $this->expectExceptionMessage('Invalid cast attribute: invalid. Use a valid one like datetime,immutable_datetime');
+        $this->expectExceptionMessage(
+            'Invalid cast attribute: invalid. Use a valid one like datetime,immutable_datetime'
+        );
 
         // Actions
         CastResolver::resolve('invalid');

--- a/tests/Unit/Model/Casts/DateTime/BaseDateTimeCastTest.php
+++ b/tests/Unit/Model/Casts/DateTime/BaseDateTimeCastTest.php
@@ -11,7 +11,10 @@ class BaseDateTimeCastTest extends TestCase
     public function testShouldSet(): void
     {
         // Set
-        $dateInDateTime = DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45');
+        $dateInDateTime = DateTime::createFromFormat(
+            'd/m/Y H:i:s',
+            '08/10/2025 12:30:45'
+        );
         $dateTimeCast = new DateTimeCast();
 
         // Actions

--- a/tests/Unit/Model/Casts/DateTime/ImmutableDateTimeCastTest.php
+++ b/tests/Unit/Model/Casts/DateTime/ImmutableDateTimeCastTest.php
@@ -13,10 +13,11 @@ class ImmutableDateTimeCastTest extends TestCase
         // Set
         $timestamp = new UTCDateTime(
             DateTimeImmutable::createFromFormat(
-                'd/m/Y H:i:s', '08/10/2025 12:30:45'
+                'd/m/Y H:i:s',
+                '08/10/2025 12:30:45'
             )
         );
-        
+
         $immutableDateTimeCast = new ImmutableDateTimeCast();
 
         // Actions

--- a/tests/Unit/Model/Exception/ModelNotFoundExceptionTest.php
+++ b/tests/Unit/Model/Exception/ModelNotFoundExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Model\Exception;
 
 use Mongolid\TestCase;
@@ -17,6 +18,9 @@ final class ModelNotFoundExceptionTest extends TestCase
 
         // Assertions
         $this->assertSame('User', $modelResult);
-        $this->assertSame('No query results for model [User].', $messageResult);
+        $this->assertSame(
+            'No query results for model [User].',
+            $messageResult
+        );
     }
 }

--- a/tests/Unit/Model/HasAttributesTraitTest.php
+++ b/tests/Unit/Model/HasAttributesTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Model;
 
 use DateTime;
@@ -14,7 +15,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldGetAttributeFromMutator(): void
     {
         // Set
-        $model = new class()
+        $model = new class ()
         {
             use HasAttributesTrait;
             use HasRelationsTrait;
@@ -41,7 +42,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldIgnoreMutators(): void
     {
         // Set
-        $model = new class()
+        $model = new class ()
         {
             use HasAttributesTrait;
             use HasRelationsTrait;
@@ -68,7 +69,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldSetAttributeFromMutator(): void
     {
         // Set
-        $model = new class()
+        $model = new class ()
         {
             use HasAttributesTrait;
             use HasRelationsTrait;
@@ -102,7 +103,7 @@ final class HasAttributesTraitTest extends TestCase
         array $expected
     ) {
         // Set
-        $model = new class($fillable, $guarded) implements HasAttributesInterface
+        $model = new class ($fillable, $guarded) implements HasAttributesInterface
         {
             use HasAttributesTrait;
             use HasRelationsTrait;
@@ -264,7 +265,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldForceFillAttributes(): void
     {
         // Set
-        $model = new class() implements HasAttributesInterface
+        $model = new class () implements HasAttributesInterface
         {
             use HasAttributesTrait;
             use HasRelationsTrait;
@@ -286,7 +287,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldBeCastableToArray(): void
     {
         // Set
-        $model = new class()
+        $model = new class ()
         {
             use HasAttributesTrait;
             use HasRelationsTrait;
@@ -305,7 +306,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldSetOriginalAttributes(): void
     {
         // Set
-        $model = new class() implements HasAttributesInterface
+        $model = new class () implements HasAttributesInterface
         {
             use HasAttributesTrait;
             use HasRelationsTrait;
@@ -325,7 +326,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldFallbackOriginalAttributesIfUnserializationFails(): void
     {
         // Set
-        $model = new class() implements HasAttributesInterface
+        $model = new class () implements HasAttributesInterface
         {
             use HasAttributesTrait;
             use HasRelationsTrait;
@@ -350,7 +351,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldCheckIfAttributeIsSet(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
         };
 
@@ -366,7 +367,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldCheckIfMutatedAttributeIsSet(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
             public bool $mutable = true;
 
@@ -384,13 +385,12 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldCastAttributeToDateTimeWhenLoadingFromDatabase(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
             protected array $casts = [
                 'expires_at' => 'datetime',
                 'birthdate' => 'immutable_datetime',
             ];
-
         };
         $model->expires_at = new UTCDateTime(
             DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45')
@@ -401,7 +401,10 @@ final class HasAttributesTraitTest extends TestCase
 
         // Assertions
         $this->assertInstanceOf(DateTime::class, $model->expires_at);
-        $this->assertSame('08/10/2025 12:30:45', $model->expires_at->format('d/m/Y H:i:s'));
+        $this->assertSame(
+            '08/10/2025 12:30:45',
+            $model->expires_at->format('d/m/Y H:i:s')
+        );
 
         $this->assertInstanceOf(DateTimeImmutable::class, $model->birthdate);
         $this->assertSame('02/04/1990', $model->birthdate->format('d/m/Y'));
@@ -410,7 +413,7 @@ final class HasAttributesTraitTest extends TestCase
     public function testShouldCastAttributeToUTCDateTimeWhenSettingAttributes(): void
     {
         // Set
-        $model = new class() extends AbstractModel
+        $model = new class () extends AbstractModel
         {
             protected array $casts = [
                 'expires_at' => 'datetime',
@@ -419,10 +422,16 @@ final class HasAttributesTraitTest extends TestCase
         };
 
         // Actions
-        $model->expires_at = DateTime::createFromFormat('d/m/Y H:i:s', '08/10/2025 12:30:45');
+        $model->expires_at = DateTime::createFromFormat(
+            'd/m/Y H:i:s',
+            '08/10/2025 12:30:45'
+        );
 
         // Assertions
-        $this->assertInstanceOf(UTCDateTime::class, $model->getDocumentAttributes()['expires_at']);
+        $this->assertInstanceOf(
+            UTCDateTime::class,
+            $model->getDocumentAttributes()['expires_at']
+        );
         $this->assertInstanceOf(DateTime::class, $model->expires_at);
     }
 

--- a/tests/Unit/Model/HasLegacyRelationTraitTest.php
+++ b/tests/Unit/Model/HasLegacyRelationTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Model;
 
 use Mockery as m;
@@ -19,7 +20,10 @@ final class HasLegacyRelationTraitTest extends TestCase
         // Set
         $model = new Product();
         $model->_id = $fieldValue;
-        $priceModel = $this->instance(Price::class, m::mock(Price::class)->makePartial());
+        $priceModel = $this->instance(
+            Price::class,
+            m::mock(Price::class)->makePartial()
+        );
         $cacheComponent = $this->instance(
             CacheComponentInterface::class,
             m::mock(CacheComponent::class)->makePartial()
@@ -50,7 +54,10 @@ final class HasLegacyRelationTraitTest extends TestCase
         $model = new Product();
         $model->_id = $fieldValue;
         $expected = new Price();
-        $builder = $this->instance(Price::class, m::mock(Price::class)->makePartial());
+        $builder = $this->instance(
+            Price::class,
+            m::mock(Price::class)->makePartial()
+        );
         $cacheComponent = $this->instance(
             CacheComponentInterface::class,
             m::mock(CacheComponent::class)->makePartial()
@@ -81,11 +88,19 @@ final class HasLegacyRelationTraitTest extends TestCase
             ],
             'referenced by objectId represented as string' => [
                 'fieldValue' => '577afb0b4d3cec136058fa82',
-                'expectedQuery' => ['_id' => new ObjectId('577afb0b4d3cec136058fa82')],
+                'expectedQuery' => [
+                    '_id' => new ObjectId(
+                        '577afb0b4d3cec136058fa82'
+                    ),
+                ],
             ],
             'referenced by an objectId itself' => [
                 'fieldValue' => new ObjectId('577afb0b4d3cec136058fa82'),
-                'expectedQuery' => ['_id' => new ObjectId('577afb0b4d3cec136058fa82')],
+                'expectedQuery' => [
+                    '_id' => new ObjectId(
+                        '577afb0b4d3cec136058fa82'
+                    ),
+                ],
             ],
         ];
     }

--- a/tests/Unit/Model/HasRelationsTraitTest.php
+++ b/tests/Unit/Model/HasRelationsTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Model;
 
 use Mockery as m;
@@ -20,7 +21,10 @@ final class HasRelationsTraitTest extends TestCase
         $model = new ReferencedUser();
         $model->parent_id = $fieldValue;
 
-        $builder = $this->instance(Builder::class, m::mock(Builder::class)->makePartial());
+        $builder = $this->instance(
+            Builder::class,
+            m::mock(Builder::class)->makePartial()
+        );
         $expected = new ReferencedUser();
 
         // Expectations
@@ -41,7 +45,10 @@ final class HasRelationsTraitTest extends TestCase
         // Set
         $model = new ReferencedUser();
 
-        $builder = $this->instance(Builder::class, m::mock(Builder::class)->makePartial());
+        $builder = $this->instance(
+            Builder::class,
+            m::mock(Builder::class)->makePartial()
+        );
 
         // Expectations
         $builder
@@ -65,7 +72,10 @@ final class HasRelationsTraitTest extends TestCase
         $model = new ReferencedUser();
         $model->siblings_ids = $fieldValue;
 
-        $builder = $this->instance(Builder::class, m::mock(Builder::class)->makePartial());
+        $builder = $this->instance(
+            Builder::class,
+            m::mock(Builder::class)->makePartial()
+        );
         $expected = new EmbeddedCursor([]);
 
         // Expectations
@@ -141,7 +151,10 @@ final class HasRelationsTraitTest extends TestCase
 
         // Assertions
         $this->assertInstanceOf(EmbeddedCursor::class, $result);
-        $this->assertContainsOnlyInstancesOf(EmbeddedUser::class, $result->all());
+        $this->assertContainsOnlyInstancesOf(
+            EmbeddedUser::class,
+            $result->all()
+        );
         $this->assertSame($expectedItems, $result->all());
     }
 
@@ -154,11 +167,19 @@ final class HasRelationsTraitTest extends TestCase
             ],
             'referenced by objectId represented as string' => [
                 'fieldValue' => '577afb0b4d3cec136058fa82',
-                'expectedQuery' => ['_id' => new ObjectId('577afb0b4d3cec136058fa82')],
+                'expectedQuery' => [
+                    '_id' => new ObjectId(
+                        '577afb0b4d3cec136058fa82'
+                    ),
+                ],
             ],
             'referenced by an objectId itself' => [
                 'fieldValue' => new ObjectId('577afb0b4d3cec136058fa82'),
-                'expectedQuery' => ['_id' => new ObjectId('577afb0b4d3cec136058fa82')],
+                'expectedQuery' => [
+                    '_id' => new ObjectId(
+                        '577afb0b4d3cec136058fa82'
+                    ),
+                ],
             ],
         ];
     }
@@ -172,14 +193,33 @@ final class HasRelationsTraitTest extends TestCase
             ],
             'referenced by objectId represented as string' => [
                 'fieldValue' => '577afb0b4d3cec136058fa82',
-                'expectedQuery' => ['_id' => ['$in' => [new ObjectId('577afb0b4d3cec136058fa82')]]],
+                'expectedQuery' => [
+                    '_id' => [
+                        '$in' => [new ObjectId(
+                            '577afb0b4d3cec136058fa82'
+                        ),
+                        ],
+                    ],
+                ],
             ],
             'referenced by an objectId itself' => [
                 'fieldValue' => new ObjectId('577afb0b4d3cec136058fa82'),
-                'expectedQuery' => ['_id' => ['$in' => [new ObjectId('577afb0b4d3cec136058fa82')]]],
+                'expectedQuery' => [
+                    '_id' => [
+                        '$in' => [new ObjectId(
+                            '577afb0b4d3cec136058fa82'
+                        ),
+                        ],
+                    ],
+                ],
             ],
             'series of objectIds' => [
-                'fieldValue' => [new ObjectId('577afb0b4d3cec136058fa82'), new ObjectId('577afb7e4d3cec136258fa83')],
+                'fieldValue' => [new ObjectId(
+                    '577afb0b4d3cec136058fa82'
+                ), new ObjectId(
+                    '577afb7e4d3cec136258fa83'
+                ),
+                ],
                 'expectedQuery' => [
                     '_id' => [
                         '$in' => [

--- a/tests/Unit/Query/BuilderTest.php
+++ b/tests/Unit/Query/BuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Query;
 
 use InvalidArgumentException;
@@ -56,7 +57,12 @@ final class BuilderTest extends TestCase
             ->with(
                 ['_id' => 123],
                 $model,
-                ['upsert' => true, 'writeConcern' => new WriteConcern($writeConcern)]
+                [
+                    'upsert' => true,
+                    'writeConcern' => new WriteConcern(
+                        $writeConcern
+                    ),
+                ]
             )->andReturn($operationResult);
 
         $operationResult
@@ -243,7 +249,7 @@ final class BuilderTest extends TestCase
         $connection = m::mock(Connection::class);
         $builder = new Builder($connection);
 
-        $model = new class() extends ReplaceCollectionModel
+        $model = new class () extends ReplaceCollectionModel
         {
             public array $fillable = [
                 'name',
@@ -300,7 +306,7 @@ final class BuilderTest extends TestCase
         $connection = m::mock(Connection::class);
         $builder = new Builder($connection);
 
-        $model = new class() extends ReplaceCollectionModel
+        $model = new class () extends ReplaceCollectionModel
         {
         };
         $collection = m::mock(Collection::class);
@@ -427,7 +433,10 @@ final class BuilderTest extends TestCase
         // Expectations
         $collection
             ->expects('deleteOne')
-            ->with(['_id' => 123], ['writeConcern' => new WriteConcern($writeConcern)])
+            ->with(
+                ['_id' => 123],
+                ['writeConcern' => new WriteConcern($writeConcern)]
+            )
             ->andReturn($operationResult);
 
         $operationResult
@@ -465,7 +474,7 @@ final class BuilderTest extends TestCase
     ): void {
         // Set
         $connection = m::mock(Connection::class);
-        $builder = m::mock(Builder::class.'[getCollection]', [$connection]);
+        $builder = m::mock(Builder::class . '[getCollection]', [$connection]);
         $collection = m::mock(Collection::class);
         $model = m::mock(ModelInterface::class);
 
@@ -516,7 +525,10 @@ final class BuilderTest extends TestCase
         $this->assertInstanceOf(Cursor::class, $result);
         $this->assertSame($collection, $collectionResult);
         $this->assertSame('find', $commandResult);
-        $this->assertSame([$preparedQuery, ['projection' => $projection, 'eagerLoads' => []]], $paramsResult);
+        $this->assertSame(
+            [$preparedQuery, ['projection' => $projection, 'eagerLoads' => []]],
+            $paramsResult
+        );
     }
 
     public function testShouldGetWithWhereQueryEagerLoadingModels(): void
@@ -590,14 +602,17 @@ final class BuilderTest extends TestCase
         $this->assertInstanceOf(CacheableCursor::class, $result);
         $this->assertSame($collection, $collectionResult);
         $this->assertSame('find', $commandResult);
-        $this->assertSame([$preparedQuery, ['projection' => $projection, 'eagerLoads' => []]], $paramsResult);
+        $this->assertSame(
+            [$preparedQuery, ['projection' => $projection, 'eagerLoads' => []]],
+            $paramsResult
+        );
     }
 
     public function testShouldGetAll(): void
     {
         // Set
         $connection = m::mock(Connection::class);
-        $builder = m::mock(Builder::class.'[where]', [$connection]);
+        $builder = m::mock(Builder::class . '[where]', [$connection]);
         $mongolidCursor = m::mock(Cursor::class);
         $model = m::mock(ModelInterface::class);
 
@@ -643,7 +658,7 @@ final class BuilderTest extends TestCase
     {
         // Set
         $connection = m::mock(Connection::class);
-        $builder = m::mock(Builder::class.'[where]', [$connection]);
+        $builder = m::mock(Builder::class . '[where]', [$connection]);
         $builder->shouldAllowMockingProtectedMethods();
         $collection = m::mock(Collection::class);
         $query = 123;
@@ -711,7 +726,7 @@ final class BuilderTest extends TestCase
     {
         // Set
         $connection = m::mock(Connection::class);
-        $builder = m::mock(Builder::class.'[where]', [$connection]);
+        $builder = m::mock(Builder::class . '[where]', [$connection]);
         $builder->shouldAllowMockingProtectedMethods();
         $collection = m::mock(Collection::class);
         $query = 123;
@@ -747,7 +762,9 @@ final class BuilderTest extends TestCase
 
         // Expectations
         $this->expectException(ModelNotFoundException::class);
-        $this->expectExceptionMessage('No query results for model ['.get_class($model).'].');
+        $this->expectExceptionMessage(
+            'No query results for model [' . $model::class . '].'
+        );
 
         // Actions
         $builder->firstOrFail($model, null);
@@ -832,7 +849,9 @@ final class BuilderTest extends TestCase
 
         // Expectations
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid projection: 'invalid-key' => 'invalid-value'");
+        $this->expectExceptionMessage(
+            "Invalid projection: 'invalid-key' => 'invalid-value'"
+        );
 
         // Actions
         $this->callProtected($builder, 'prepareProjection', [$data]);
@@ -923,7 +942,10 @@ final class BuilderTest extends TestCase
     protected function getEventService(): EventTriggerService
     {
         if (!Container::has(EventTriggerService::class)) {
-            Container::instance(EventTriggerService::class, m::mock(EventTriggerService::class));
+            Container::instance(
+                EventTriggerService::class,
+                m::mock(EventTriggerService::class)
+            );
         }
 
         return Container::make(EventTriggerService::class);
@@ -931,7 +953,7 @@ final class BuilderTest extends TestCase
 
     protected function expectEventToBeFired(string $event, ModelInterface $model, bool $halt, bool $return = true): void
     {
-        $event = 'mongolid.'.$event.': '.get_class($model);
+        $event = 'mongolid.' . $event . ': ' . $model::class;
 
         $this->getEventService()
             ->expects()
@@ -941,7 +963,7 @@ final class BuilderTest extends TestCase
 
     protected function expectEventNotToBeFired(string $event, ModelInterface $model): void
     {
-        $event = 'mongolid.'.$event.': '.get_class($model);
+        $event = 'mongolid.' . $event . ': ' . $model::class;
 
         $this->getEventService()
             ->expects()

--- a/tests/Unit/Query/EagerLoader/CacheTest.php
+++ b/tests/Unit/Query/EagerLoader/CacheTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Query\EagerLoader;
 
 use Mongolid\Cursor\SchemaEmbeddedCursor;
@@ -21,7 +22,10 @@ class CacheTest extends TestCase
         $product1->_id = 123;
         $product2 = new Product();
         $product2->_id = 456;
-        $products = new SchemaEmbeddedCursor(Product::class, [$product1, $product2]);
+        $products = new SchemaEmbeddedCursor(
+            Product::class,
+            [$product1, $product2]
+        );
 
         $cache = new Cache($cacheComponent);
         $eagerLoadedModels = [

--- a/tests/Unit/Query/EagerLoader/EagerLoaderTest.php
+++ b/tests/Unit/Query/EagerLoader/EagerLoaderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Query\EagerLoader;
 
 use ArrayIterator;
@@ -16,7 +17,10 @@ class EagerLoaderTest extends TestCase
     public function testShouldCacheQueries(): void
     {
         // Set
-        $cacheComponent = Container::instance(CacheComponentInterface::class, m::mock(CacheComponentInterface::class));
+        $cacheComponent = Container::instance(
+            CacheComponentInterface::class,
+            m::mock(CacheComponentInterface::class)
+        );
         $price = Container::instance(Price::class, m::mock(Price::class));
         $eagerLoader = new EagerLoader();
         $product = new Product();
@@ -41,15 +45,18 @@ class EagerLoaderTest extends TestCase
         $eagerLoader->cache($products, [
             'price' => [
                 'key' => '_id',
-                'model' => Price::class
-            ]
+                'model' => Price::class,
+            ],
         ]);
     }
 
     public function testShouldCacheQueriesWithObjectIds(): void
     {
         // Set
-        $cacheComponent = Container::instance(CacheComponentInterface::class, m::mock(CacheComponentInterface::class));
+        $cacheComponent = Container::instance(
+            CacheComponentInterface::class,
+            m::mock(CacheComponentInterface::class)
+        );
         $price = Container::instance(Price::class, m::mock(Price::class));
         $eagerLoader = new EagerLoader();
         $product = new Product();
@@ -75,15 +82,18 @@ class EagerLoaderTest extends TestCase
         $eagerLoader->cache($products, [
             'price' => [
                 'key' => '_id',
-                'model' => Price::class
-            ]
+                'model' => Price::class,
+            ],
         ]);
     }
 
     public function testShouldNotCacheIfEagerLoadingIsEmpty(): void
     {
         // Set
-        $cacheComponent = Container::instance(CacheComponentInterface::class, m::mock(CacheComponentInterface::class));
+        $cacheComponent = Container::instance(
+            CacheComponentInterface::class,
+            m::mock(CacheComponentInterface::class)
+        );
         $price = Container::instance(Price::class, m::mock(Price::class));
         $eagerLoader = new EagerLoader();
         $product = new Product();
@@ -107,7 +117,10 @@ class EagerLoaderTest extends TestCase
     public function testShouldNotCacheIfCursorIsEmpty(): void
     {
         // Set
-        $cacheComponent = Container::instance(CacheComponentInterface::class, m::mock(CacheComponentInterface::class));
+        $cacheComponent = Container::instance(
+            CacheComponentInterface::class,
+            m::mock(CacheComponentInterface::class)
+        );
         $price = Container::instance(Price::class, m::mock(Price::class));
         $eagerLoader = new EagerLoader();
         $products = new ArrayIterator([]);
@@ -125,15 +138,18 @@ class EagerLoaderTest extends TestCase
         $eagerLoader->cache($products, [
             'price' => [
                 'key' => '_id',
-                'model' => Price::class
-            ]
+                'model' => Price::class,
+            ],
         ]);
     }
 
     public function testShouldNotCacheIfItDidNotFindAnyIdsOnModels(): void
     {
         // Set
-        $cacheComponent = Container::instance(CacheComponentInterface::class, m::mock(CacheComponentInterface::class));
+        $cacheComponent = Container::instance(
+            CacheComponentInterface::class,
+            m::mock(CacheComponentInterface::class)
+        );
         $price = Container::instance(Price::class, m::mock(Price::class));
         $eagerLoader = new EagerLoader();
         $product = new Product();
@@ -156,8 +172,8 @@ class EagerLoaderTest extends TestCase
         $eagerLoader->cache($products, [
             'price' => [
                 'key' => '_id',
-                'model' => Price::class
-            ]
+                'model' => Price::class,
+            ],
         ]);
     }
 }

--- a/tests/Unit/Query/EagerLoader/ExtractorTest.php
+++ b/tests/Unit/Query/EagerLoader/ExtractorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Query\EagerLoader;
 
 use Mongolid\Query\EagerLoader\Exception\EagerLoaderException;
@@ -15,7 +16,7 @@ class ExtractorTest extends TestCase
         $eagerLoader = [
             'price' => [
                 'key' => '_id',
-                'model' => Price::class
+                'model' => Price::class,
             ],
             'shop' => [
                 'key' => 'skus.shop_id',
@@ -28,20 +29,20 @@ class ExtractorTest extends TestCase
         $product->skus = [
             [
                 'name' => 'Playstation',
-                'shop_id' => 12345
-            ]
+                'shop_id' => 12345,
+            ],
         ];
         $expected = [
             'price' => [
                 'key' => '_id',
-                'model' => \Mongolid\Tests\Stubs\Price::class,
+                'model' => Price::class,
                 'ids' => [
                     123 => 123,
                 ],
             ],
             'shop' => [
                 'key' => 'skus.shop_id',
-                'model' => \Mongolid\Tests\Stubs\Legacy\Shop::class,
+                'model' => Shop::class,
                 'ids' => [
                     12345 => 12345,
                 ],
@@ -61,7 +62,7 @@ class ExtractorTest extends TestCase
         $eagerLoader = [
             'price' => [
                 'key' => 'unexistentReferencedId',
-                'model' => Price::class
+                'model' => Price::class,
             ],
         ];
         $extractor = new Extractor($eagerLoader);
@@ -70,8 +71,8 @@ class ExtractorTest extends TestCase
         $product->skus = [
             [
                 'name' => 'Playstation',
-                'shop_id' => 12345
-            ]
+                'shop_id' => 12345,
+            ],
         ];
 
         // Expectations

--- a/tests/Unit/Query/ModelMapperTest.php
+++ b/tests/Unit/Query/ModelMapperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mongolid\Query;
 
 use DateTime;


### PR DESCRIPTION
This PR is the tenth in a series of PRs aimed at adding coding standards to Mongolid (the PR "https://github.com/leroy-merlin-br/mongolid/pull/247" is being split, and this is the seventh part, related to the Unit tests context).

The additions made here are being split from the PR: 
https://github.com/leroy-merlin-br/mongolid/pull/209/files#diff-44c6c764ba381928e3221e4690c18dc0fe596311af5b123d5d2089ffc4db52af

And are tested in the project: https://github.com/JoaoFerrazfs/Mongo-PHP-Docker_BaseProject